### PR TITLE
feat:add Streamlit presentation layer (issue #11 + #12)

### DIFF
--- a/docs/presentation-layer-spec.md
+++ b/docs/presentation-layer-spec.md
@@ -1,0 +1,579 @@
+# CodeLens Presentation Layer — Implementation Spec
+
+> Combined specification for issues #11 (Admin Panel) and #12 (Demo Interface).
+> Use this document as the single source of truth when building the Streamlit
+> presentation layer for CodeLens.
+
+---
+
+## 1. Project context (what CodeLens is)
+
+CodeLens indexes a codebase into a Neo4j knowledge graph, identifies business
+domains via community detection, and exposes the graph through an MCP server so
+AI agents can query structural code context. The full living spec is in
+`docs/LIVING_SPEC.md`.
+
+This document covers only the **presentation layer**:
+
+- **Admin Panel** (#11) — admin-only management UI for repos, domains, users
+- **Demo Interface** (#12) — chat UI with persona toggle for showing the system
+  to stakeholders
+
+Both run as a single Streamlit application that talks to a FastAPI backend
+over HTTP. The Streamlit app does **not** access Neo4j or MCP tools directly.
+
+---
+
+## 2. Architecture decision
+
+**Streamlit as a thin client calling FastAPI over HTTP.**
+ADR-003 resolved with this choice. Multi-tier separation is preserved because
+Streamlit (presentation) and FastAPI (application) communicate over a network
+boundary, and Streamlit never accesses the data layer directly.
+
+```
+Browser
+   │ HTTP
+Streamlit (presentation layer) ← THIS IS WHAT WE'RE BUILDING
+   │ HTTP (REST + SSE)
+FastAPI (application layer) ← built by backend team
+   │ Cypher / MCP
+Neo4j (data layer) ← built by backend team
+```
+
+All data access in Streamlit goes through `requests.get/post/...` calls to
+FastAPI endpoints. No direct DB access. No direct MCP tool calls.
+
+---
+
+## 3. Project structure
+
+```
+streamlit_app/
+├── Home.py                       # Login page (entry point)
+├── pages/
+│   ├── 1_Demo.py                 # Chat UI (any authenticated user)
+│   ├── 2_Admin_Dashboard.py      # Admin overview (admin only)
+│   ├── 3_Admin_Repos.py          # Repo CRUD (admin only)
+│   ├── 4_Admin_Domains.py        # Domain summaries (admin only)
+│   └── 5_Admin_Users.py          # User management (admin only)
+├── lib/
+│   ├── __init__.py
+│   ├── api_client.py             # Wrapper around requests for FastAPI calls
+│   ├── auth.py                   # Auth helpers (require_login, require_admin)
+│   └── prompts.py                # Persona system prompts (for demo agent)
+└── requirements.txt              # streamlit, requests, etc.
+```
+
+Streamlit auto-discovers `pages/` and shows them in the sidebar. The number
+prefix controls ordering. Underscores become spaces in the display label.
+
+---
+
+## 4. Authentication and session management
+
+### 4.1 Single shared login
+
+One login page (`Home.py`) for both admin and demo use. There is no separate
+admin login. The login form posts to `POST /auth/login` and receives a JWT
+containing `{ user_id, role, email, must_change_password }`.
+
+### 4.2 Session state keys
+
+Store these in `st.session_state` after successful login:
+
+```python
+st.session_state["token"]                    # JWT string
+st.session_state["user_id"]                  # int
+st.session_state["email"]                    # str
+st.session_state["role"]                     # "user" | "admin"
+st.session_state["must_change_password"]     # bool
+```
+
+### 4.3 Page-level guards
+
+Every page checks auth at the top:
+
+```python
+# Any authenticated user
+from lib.auth import require_login
+require_login()  # redirects to Home.py if no token
+
+# Admin-only pages
+from lib.auth import require_admin
+require_admin()  # shows access denied + redirects if role != "admin"
+```
+
+### 4.4 Sidebar visibility
+
+`user` role sees only **Demo** in the sidebar. `admin` role sees Demo +
+Dashboard + Repos + Domains + Users. This is achieved by hiding admin pages
+when the role is not admin (Streamlit's `st.navigation` API or by setting
+`PAGE_VISIBILITY` config; a simple workaround is showing a friendly "Access
+Denied" message instead of the page content for non-admins).
+
+### 4.5 First-login flow
+
+If JWT contains `must_change_password: true`, redirect the user to a Change
+Password view immediately after login. Block all other navigation until the
+password is changed. Once changed, call `POST /auth/change-password`, get a
+new JWT, and resume normal flow.
+
+### 4.6 Self-registration
+
+**Disabled.** The login page has no "Sign up" link. New users are created only
+by an admin via the Users page. The first admin is created by a backend seed
+script.
+
+### 4.7 Logout
+
+Sidebar has a Logout button. Clears `st.session_state` entirely and redirects
+to `Home.py`. Optionally calls `POST /auth/logout` for backend token blacklist
+(not required for MVP).
+
+---
+
+## 5. API client (`lib/api_client.py`)
+
+A thin wrapper around `requests` that:
+
+- Reads `BASE_URL` from environment (default `http://localhost:8000`)
+- Attaches `Authorization: Bearer <token>` header on every call (when a token
+  exists in session state)
+- Handles common error cases: 401 → clear session and redirect to login;
+  403 → show "permission denied" toast; 5xx → show generic error toast
+- Returns parsed JSON or raises a typed exception
+- Has helpers like `get(path)`, `post(path, json=...)`, `patch(...)`,
+  `delete(...)`, and a streaming helper for SSE
+
+This lets every page call e.g. `api.get("/admin/repos")` without repeating
+boilerplate.
+
+---
+
+## 6. Admin Panel (issue #11)
+
+### 6.1 Admin Dashboard (`pages/2_Admin_Dashboard.py`)
+
+Sections:
+
+1. **KPI cards** (4 metrics in columns)
+   - Total repos
+   - Total domains
+   - Total users
+   - Indexing jobs in last 24h
+
+2. **Recent indexing jobs** (table, last 5)
+   - Columns: repo, started_at, duration, status (icon), trigger
+   - Failed rows expandable to show error message
+
+3. **System health card**
+   - Neo4j connection: ✓ / ✗
+   - LLM API (Gemini 2.5 Flash): ✓ / rate limited / down
+   - Last successful indexing: relative time
+
+4. **Quick actions**
+   - "+ Add Repo" button (opens dialog, same as on Repos page)
+   - Navigation links
+
+Data sources: `GET /admin/dashboard/stats`, `GET /admin/jobs?limit=5`,
+`GET /admin/health`.
+
+### 6.2 Repos (`pages/3_Admin_Repos.py`)
+
+Two views in one page, switched via session state:
+
+**List view (default)**
+- Table with columns: name, branch, status (indexed/indexing/failed),
+  last_indexed_at, function_count, domain_count
+- Each row has actions: View Detail, Re-index Now, Delete
+- Top of page: "+ Add Repo" button
+
+**Add Repo dialog (`@st.dialog`)**
+- Fields: GitHub URL (required), branch (default "main")
+- Light validation: URL format check
+- On submit: `POST /admin/repos` with `{ github_url, branch }`
+- On success: close dialog, show toast, refresh table
+
+**Re-index button**
+- Calls `POST /admin/repos/{id}/reindex`
+- Returns 202 immediately, job runs async
+- Show toast: "Re-indexing started"
+- Dashboard polls for status via periodic `st.rerun()` or auto-refresh
+
+**Delete confirmation dialog (`@st.dialog`)**
+- Triggered by Delete button on a row
+- Shows: repo name, count of functions and domains that will be lost
+- Two buttons: Cancel, Delete (Delete styled as `type="primary"` and red)
+- On confirm: `DELETE /admin/repos/{id}`, toast, refresh
+
+**Detail view** (when a repo is selected via session state)
+- Shows: repo metadata, list of domains in this repo, last 20 indexing jobs
+  for this repo
+- "← Back to list" button at top resets selection
+
+### 6.3 Domains (`pages/4_Admin_Domains.py`)
+
+Two views in one page, state-based:
+
+**List view**
+- Repo filter dropdown at the top
+- Table: domain name, member count, human_verified flag, last_updated
+- Each row has a "View →" button that sets `selected_domain_id` and re-renders
+
+**Detail view**
+- Shows: domain name, full member list (functions + classes with file:line),
+  metadata
+- Editable summary in a textarea
+- `human_verified` toggle (checkbox)
+- Two buttons: Save Changes (`PATCH /admin/domains/{id}`),
+  Re-generate with LLM (`POST /admin/domains/{id}/regenerate`)
+- "← Back to list" button at top
+
+No create or delete (domains are managed by the indexing pipeline).
+
+### 6.4 Users (`pages/5_Admin_Users.py`)
+
+Single list view with row-level actions.
+
+**Table**
+- Columns: email, role, created_at, last_login, must_change_password (badge)
+- Per-row actions: Promote to Admin / Revoke Admin (toggles based on current
+  role), Reset Password, Delete
+
+**Add User dialog (`@st.dialog`)**
+- Triggered by "+ Add User" button
+- Fields: email (required), role radio (user / admin)
+- On submit: `POST /admin/users` with `{ email, role }`
+- Backend generates a random temporary password and returns it in the response
+- A second dialog (or section in the same dialog) shows the generated password
+  with a Copy button and a clear warning that this will not be shown again
+- After Done: close, refresh table
+
+**Reset Password action**
+- `POST /admin/users/{id}/reset-password`
+- Same flow: backend returns new temporary password, show in dialog with
+  Copy button and warning
+
+**Promote / Revoke**
+- `PATCH /admin/users/{id}` with `{ role: "admin" | "user" }`
+- Toast on success, refresh table
+
+**Delete**
+- Confirmation dialog (same pattern as Repos)
+- `DELETE /admin/users/{id}`
+- Cannot delete yourself (frontend check + backend enforcement)
+
+---
+
+## 7. Demo Interface (issue #12)
+
+### 7.1 Page (`pages/1_Demo.py`)
+
+Accessible to any authenticated user. Single chat UI with sidebar controls.
+
+### 7.2 Sidebar controls
+
+```
+Repository: [my-shop-api ▼]      # hidden if only one repo
+
+Persona:
+( ) Developer
+(•) Product Manager
+( ) Legal / Compliance
+
+[+ New Conversation]
+
+─── Domains ───
+📦 Checkout (23)
+🔐 Auth (14)
+💳 Payments (31)
+👥 User Mgmt (9)
+```
+
+- **Repository dropdown**: lists indexed repos via `GET /demo/repos`. Hidden
+  if only one repo. Changing the repo clears the conversation (different
+  codebase, different context).
+- **Persona radio**: stored in `st.session_state["persona"]`. Sent to backend
+  on each chat request. Changing persona does NOT clear the conversation;
+  the change applies to the next message.
+- **New Conversation button**: clears `st.session_state.messages`.
+- **Domain browser**: lists domains for the active repo via
+  `GET /demo/repos/{id}/domains`. Clicking a domain auto-sends the message
+  `"Tell me about the [domain name] domain."` to the chat.
+
+### 7.3 Chat area
+
+Use Streamlit's built-in chat components:
+
+```python
+# Render history
+for msg in st.session_state.messages:
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+
+# Input
+if prompt := st.chat_input("Ask about the codebase..."):
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    # ... call backend, stream response
+```
+
+### 7.4 Streaming response flow
+
+When the user submits a message:
+
+1. Append user message to `st.session_state.messages`.
+2. Show "Thinking..." indicator (`st.spinner` or a placeholder).
+3. Open SSE connection to `POST /demo/chat` with body:
+   ```json
+   {
+     "message": "...",
+     "repo_id": 123,
+     "persona": "developer",
+     "history": [{"role": "user", "content": "..."}, ...]
+   }
+   ```
+4. The backend streams events. Two event types:
+   - `tool_call` — `{ "tool": "get_code_context", "args": {...}, "status": "running" }`
+     → render in an `st.status` widget so the user sees what the agent is doing
+   - `token` — `{ "delta": "some text" }`
+     → append to the assistant message and re-render with `st.write_stream`
+5. When the stream ends, append the final assistant message to
+   `st.session_state.messages`.
+
+### 7.5 Tool-call transparency
+
+Each tool call appears as a collapsible status widget in the chat:
+
+```
+🔍 Looking up apply_discount...
+   ✓ Found in pricing.py:142
+   ✓ Retrieved subgraph (8 callers, 3 callees)
+   ✓ Domain: Checkout
+```
+
+This is valuable for demo storytelling. Show it by default; user can collapse.
+
+### 7.6 Conversation state
+
+- Stored in `st.session_state.messages` only.
+- **Not persisted to DB.** Refresh, logout, or repo switch clears it.
+- Out of scope for MVP: conversation history persistence, export to PDF/MD,
+  thumbs-up/down feedback.
+
+### 7.7 Empty states
+
+- No repos indexed: friendly message + (admin only) "Go to Admin Panel" link.
+- No domains in repo: "This repository hasn't been indexed yet."
+- Empty chat (fresh conversation): example prompts like
+  - "Ask about a function: 'How does apply_discount work?'"
+  - "Browse domains in the sidebar"
+  - "Ask about a business area: 'Tell me about Checkout'"
+
+### 7.8 Error handling
+
+- MCP tool failure: insert error message into chat
+  (`❌ MCP tool timeout. Please try again.`)
+- Gemini rate limit: insert
+  (`⏳ Sending messages too quickly. Please wait ~30 seconds.`)
+- Errors stay in conversation history (do not silently clear).
+- Session expired (401 from backend): clear session, toast, redirect to
+  `Home.py`.
+
+---
+
+## 8. Persona system prompts (`lib/prompts.py`)
+
+```python
+DEVELOPER_PROMPT = """
+You are answering a software engineer. Include precise code references
+(file:line), exact function and class names, and use technical vocabulary
+freely. Be specific about types, parameters, and return values where relevant.
+Cite your sources from the structural context provided by the MCP tools.
+"""
+
+PRODUCT_PROMPT = """
+You are answering a product manager. Use plain English. Avoid code references,
+file paths, and technical jargon. Focus on the business behavior, user-facing
+implications, and edge cases. Provide example scenarios where helpful. Treat
+the underlying code structure as an implementation detail the reader does not
+need to see.
+"""
+
+LEGAL_PROMPT = """
+You are answering a compliance officer. Frame business rules as policy clauses.
+Cite the source files for traceability so any rule can be audited. Use formal,
+audit-ready language. Make it explicit when a rule has exceptions or when
+behavior depends on user attributes.
+"""
+
+PERSONA_PROMPTS = {
+    "developer": DEVELOPER_PROMPT,
+    "product": PRODUCT_PROMPT,
+    "legal": LEGAL_PROMPT,
+}
+```
+
+Streamlit only sends the persona key (`"developer"`, `"product"`, `"legal"`)
+to the backend; the backend selects the prompt and prepends it to the agent's
+system message. The prompt itself can also live on the backend — but keeping
+a copy in `lib/prompts.py` is useful for documentation and demo scripts.
+
+---
+
+## 9. UX patterns and conventions
+
+### 9.1 Loading
+Wrap every API call in `with st.spinner("Loading..."):`. For streaming chat,
+use the "Thinking..." pattern described in section 7.4.
+
+### 9.2 Errors and feedback
+- Non-critical: `st.toast("Error: ...", icon="❌")`
+- Success: `st.toast("Repo deleted", icon="✓")`
+- Blocking errors (session expired): full-page redirect with error message
+
+### 9.3 Empty states
+Every list view must have a friendly empty-state message with a primary CTA
+(e.g., "+ Add Repo") rather than just an empty table.
+
+### 9.4 Form validation
+- Client-side: minimal (email format, required fields, URL format)
+- Server-side: authoritative (Pydantic on FastAPI side)
+
+### 9.5 Confirmation dialogs
+Destructive actions (delete repo, delete user) always go through a
+`@st.dialog` confirmation showing what will be lost.
+
+### 9.6 Theme and responsiveness
+- Mobile: not supported, desktop-first
+- Theme: Streamlit default (auto dark/light from system)
+- No custom CSS for MVP
+
+---
+
+## 10. Backend endpoints needed (specification for the backend team)
+
+The Streamlit app assumes these endpoints exist on FastAPI. Build mock
+implementations or stubs as needed during development; switch to real ones
+once the backend team delivers them.
+
+### Auth
+- `POST /auth/login` → `{ token, user_id, email, role, must_change_password }`
+- `POST /auth/logout` → 204
+- `GET /auth/me` → current user info (used to refresh session)
+- `POST /auth/change-password` → new JWT
+
+### Admin: Repos
+- `GET /admin/repos`
+- `POST /admin/repos` → body `{ github_url, branch }`
+- `GET /admin/repos/{id}` → repo detail with domains and recent jobs
+- `DELETE /admin/repos/{id}`
+- `POST /admin/repos/{id}/reindex` → 202
+
+### Admin: Domains
+- `GET /admin/domains?repo_id=...`
+- `GET /admin/domains/{id}` → domain detail with members
+- `PATCH /admin/domains/{id}` → body `{ summary?, human_verified? }`
+- `POST /admin/domains/{id}/regenerate` → triggers LLM re-summary
+
+### Admin: Users
+- `GET /admin/users`
+- `POST /admin/users` → body `{ email, role }` →
+  response includes one-time `temporary_password`
+- `PATCH /admin/users/{id}` → body `{ role }`
+- `POST /admin/users/{id}/reset-password` → response includes new
+  one-time `temporary_password`
+- `DELETE /admin/users/{id}`
+
+### Admin: Misc
+- `GET /admin/jobs?limit=20` → recent indexing jobs across all repos
+- `GET /admin/dashboard/stats` → KPI numbers
+- `GET /admin/health` → Neo4j and LLM API status
+
+### Demo
+- `GET /demo/repos` → repos accessible to the current user
+- `GET /demo/repos/{id}/domains` → domain list for sidebar
+- `POST /demo/chat` (Server-Sent Events) → streamed agent response with
+  interleaved `tool_call` and `token` events
+
+---
+
+## 11. LLM choice (Gemini 2.5 Flash)
+
+The backend agent uses **Gemini 2.5 Flash** via `google-genai` (already a
+dependency in `pyproject.toml`). Reasoning:
+
+- Gemini 2.0 Flash was deprecated in March 2026 and is no longer available
+  for new projects.
+- Free tier on 2.5 Flash gives 10 RPM and 250 RPD — sufficient for demo and
+  development.
+- Same provider used for domain summaries — single LLM dependency project-wide.
+- Fallback to **Gemini 2.5 Flash-Lite** (15 RPM / 1000 RPD) if rate limits
+  become a problem during heavy demo usage.
+
+The agent uses Gemini's **native function calling** — no LangGraph, no agent
+SDK. The agent loop is roughly:
+
+1. Send user message + history + tool declarations to Gemini.
+2. If response is a tool call: execute the MCP tool via the MCP server,
+   append the result to history, loop.
+3. If response is text: stream tokens to the client.
+
+This is implemented on the FastAPI side, not in Streamlit.
+
+---
+
+## 12. Out of scope (explicit deferrals)
+
+To keep MVP tight, the following are deferred to V2:
+
+- Conversation persistence to DB
+- Conversation export (PDF / Markdown)
+- User feedback (thumbs up / thumbs down)
+- Email-based password reset (admin-mediated only for MVP)
+- Mobile-responsive layout
+- Multi-language UI (English only)
+- Pagination on lists (last 20 / 50 hardcoded for MVP)
+- WebSocket-based live progress (use `st.rerun()` polling instead)
+- Custom theme / branding
+- Audit log UI
+
+---
+
+## 13. Development order suggestion
+
+If building from scratch with no backend yet, work in this order:
+
+1. `Home.py` with login form (mock auth — accepts any email/password,
+   stores fake JWT in session state with `role: "admin"`)
+2. `lib/api_client.py` skeleton with mock responses
+3. `pages/2_Admin_Dashboard.py` with mock data
+4. `pages/3_Admin_Repos.py` with mock data and dialogs
+5. `pages/5_Admin_Users.py` with mock data and dialogs
+6. `pages/4_Admin_Domains.py` with mock data
+7. `pages/1_Demo.py` with mock streaming (yields fake tokens)
+8. Wire `lib/api_client.py` to real FastAPI endpoints once backend is ready
+
+This order builds the frame first, then fills in functionality. Mock data
+keeps the UI working in isolation while the backend is still being built.
+
+---
+
+## 14. Acceptance criteria
+
+The presentation layer is "done" when:
+
+- A user can log in via `Home.py`
+- Admin sees Dashboard, Repos, Domains, Users, Demo in the sidebar; non-admin
+  sees only Demo
+- Admin can: add a repo, delete a repo (with confirmation), re-index a repo,
+  edit a domain summary, regenerate a domain summary, add a user, reset a
+  user's password, promote/revoke admin, delete a user
+- Demo user can: select a repo, choose a persona, click a domain, ask
+  free-text questions, see streaming responses with tool-call transparency,
+  start a new conversation
+- All data access goes through FastAPI (no direct Neo4j or MCP imports in
+  Streamlit code)
+- All destructive actions require confirmation
+- Logout works and clears session
+- Empty states show friendly messages

--- a/streamlit_app/.streamlit/config.toml
+++ b/streamlit_app/.streamlit/config.toml
@@ -1,0 +1,9 @@
+[theme]
+primaryColor = "#6366F1"
+backgroundColor = "#0F172A"
+secondaryBackgroundColor = "#1E293B"
+textColor = "#F1F5F9"
+font = "sans serif"
+
+[server]
+headless = true

--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -1,0 +1,164 @@
+import streamlit as st
+
+# Read auth state before set_page_config (session_state is safe to read first)
+_logged_in = bool(st.session_state.get("token"))
+
+st.set_page_config(
+    page_title="CodeLens",
+    page_icon="◈",
+    layout="wide",
+    initial_sidebar_state="expanded" if _logged_in else "collapsed",
+)
+
+import lib.api_client as api
+from lib.auth import logout
+from lib.styles import apply_styles
+
+apply_styles()
+
+# ---------------------------------------------------------------------------
+# Login forms
+# ---------------------------------------------------------------------------
+
+def _login_form():
+    _, col, _ = st.columns([1, 1.3, 1])
+    with col:
+        st.markdown("""
+        <div style="text-align:center;padding:40px 0 28px">
+            <div class="cl-login-logo">◈</div>
+            <div class="cl-login-title">CodeLens</div>
+            <div class="cl-login-sub">Code Intelligence Platform</div>
+        </div>
+        """, unsafe_allow_html=True)
+
+        with st.form("login_form", border=True):
+            email = st.text_input("Username", placeholder="user  or  admin")
+            password = st.text_input("Password", type="password", placeholder="••••••••")
+            submitted = st.form_submit_button(
+                "Sign In →", type="primary", use_container_width=True
+            )
+
+        if submitted:
+            if not email or not password:
+                st.error("Enter your credentials.")
+                return
+            try:
+                with st.spinner(""):
+                    result = api.login(email.strip(), password)
+            except ValueError as e:
+                st.error(str(e))
+                return
+
+            st.session_state["token"] = result["token"]
+            st.session_state["user_id"] = result["user_id"]
+            st.session_state["email"] = result["email"]
+            st.session_state["role"] = result["role"]
+            st.session_state["must_change_password"] = result.get("must_change_password", False)
+            st.rerun()
+
+        st.markdown("""
+        <div class="cl-login-hint">
+            <code>user</code> / <code>user</code> &nbsp;·&nbsp;
+            <code>admin</code> / <code>admin</code>
+        </div>
+        """, unsafe_allow_html=True)
+
+
+def _change_password_form():
+    _, col, _ = st.columns([1, 1.3, 1])
+    with col:
+        st.markdown("""
+        <div style="text-align:center;padding:40px 0 20px">
+            <div class="cl-login-logo">🔒</div>
+            <div class="cl-login-title" style="font-size:1.6rem">Change Password</div>
+            <div class="cl-login-sub">Set a new password to continue.</div>
+        </div>
+        """, unsafe_allow_html=True)
+
+        with st.form("change_password_form", border=True):
+            new_pw = st.text_input("New Password", type="password")
+            confirm_pw = st.text_input("Confirm Password", type="password")
+            submitted = st.form_submit_button(
+                "Set Password →", type="primary", use_container_width=True
+            )
+
+        if submitted:
+            if new_pw != confirm_pw:
+                st.error("Passwords do not match.")
+                return
+            if len(new_pw) < 8:
+                st.error("Password must be at least 8 characters.")
+                return
+            with st.spinner(""):
+                result = api.post("/auth/change-password", json={"new_password": new_pw})
+            st.session_state["token"] = result["token"]
+            st.session_state["must_change_password"] = False
+            st.toast("Password updated.", icon="✓")
+            st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Authenticated app shell with role-based navigation
+# ---------------------------------------------------------------------------
+
+def _run_app():
+    ask_page       = st.Page("pages/1_Ask.py",              title="Ask CodeLens",  icon="💬", default=True)
+    dashboard_page = st.Page("pages/2_Admin_Dashboard.py",  title="Dashboard",     icon="📊")
+    repos_page     = st.Page("pages/3_Admin_Repos.py",      title="Repositories",  icon="🗂️")
+    domains_page   = st.Page("pages/4_Admin_Domains.py",    title="Domains",       icon="🔬")
+    users_page     = st.Page("pages/5_Admin_Users.py",      title="Users",         icon="👥")
+
+    role = st.session_state.get("role", "user")
+    nav_pages = (
+        {"": [ask_page], "Admin": [dashboard_page, repos_page, domains_page, users_page]}
+        if role == "admin"
+        else {"": [ask_page]}
+    )
+
+    with st.sidebar:
+        st.markdown("""
+        <div class="cl-brand">
+            <div class="cl-brand-icon">◈</div>
+            <span class="cl-brand-name">CodeLens</span>
+        </div>
+        """, unsafe_allow_html=True)
+
+    pg = st.navigation(nav_pages)
+
+    # Run the active page FIRST so its sidebar content renders before the footer.
+    pg.run()
+
+    # Footer always appears after all page-specific sidebar content.
+    with st.sidebar:
+        st.markdown('<div class="cl-sidebar-spacer"></div>', unsafe_allow_html=True)
+        role_label = "Admin" if role == "admin" else "User"
+        st.markdown(f"""
+        <div class="cl-sidebar-footer">
+            <div class="cl-user-info">
+                <div class="cl-user-email">{st.session_state.get('email', '')}</div>
+                <div style="margin-top:4px"><span class="cl-role-badge">{role_label}</span></div>
+            </div>
+        </div>
+        """, unsafe_allow_html=True)
+        if st.button("Logout", use_container_width=True, key="sidebar_logout"):
+            logout()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if not _logged_in:
+    # Hide sidebar and its toggle button entirely on the login screen.
+    # The pages/ auto-discovery still runs but is invisible; each page
+    # has its own require_login() / require_admin() guard anyway.
+    st.markdown("""<style>
+    [data-testid="stSidebar"],
+    [data-testid="collapsedControl"] { display: none !important; }
+    </style>""", unsafe_allow_html=True)
+    if st.session_state.get("must_change_password"):
+        _change_password_form()
+    else:
+        _login_form()
+else:
+    _run_app()

--- a/streamlit_app/lib/__init__.py
+++ b/streamlit_app/lib/__init__.py
@@ -1,0 +1,1 @@
+"""CodeLens Streamlit UI — shared library."""

--- a/streamlit_app/lib/api_client.py
+++ b/streamlit_app/lib/api_client.py
@@ -1,0 +1,582 @@
+import json as _json
+import os
+import time
+import urllib.parse
+
+import requests
+import streamlit as st
+
+# Flip to False once the FastAPI backend is running
+MOCK_MODE = True
+
+BASE_URL = os.environ.get("CODELENS_API_URL", "http://localhost:8000")
+
+# ---------------------------------------------------------------------------
+# Mock data (module-level globals — mutated by CRUD operations in mock mode)
+# ---------------------------------------------------------------------------
+
+_MOCK_REPOS = [
+    {
+        "id": 1,
+        "github_url": "https://github.com/acme/shop-api",
+        "name": "shop-api",
+        "branch": "main",
+        "status": "indexed",
+        "last_indexed_at": "2026-05-01T08:00:00Z",
+        "function_count": 342,
+        "domain_count": 7,
+    },
+    {
+        "id": 2,
+        "github_url": "https://github.com/acme/auth-service",
+        "name": "auth-service",
+        "branch": "main",
+        "status": "indexed",
+        "last_indexed_at": "2026-04-30T15:00:00Z",
+        "function_count": 118,
+        "domain_count": 3,
+    },
+]
+
+_MOCK_DOMAINS = [
+    {
+        "id": 1,
+        "repo_id": 1,
+        "name": "Checkout",
+        "member_count": 23,
+        "human_verified": True,
+        "summary": "Handles cart finalization, payment processing, order creation, and post-purchase email triggers.",
+        "last_updated": "2026-05-01T08:01:00Z",
+        "members": [
+            {"symbol": "create_order", "file": "checkout/orders.py", "line": 42},
+            {"symbol": "apply_discount", "file": "checkout/pricing.py", "line": 142},
+            {"symbol": "validate_cart", "file": "checkout/cart.py", "line": 18},
+        ],
+    },
+    {
+        "id": 2,
+        "repo_id": 1,
+        "name": "Auth",
+        "member_count": 14,
+        "human_verified": False,
+        "summary": "User authentication, session management, JWT issuance, and password hashing.",
+        "last_updated": "2026-05-01T08:01:30Z",
+        "members": [
+            {"symbol": "login_user", "file": "auth/login.py", "line": 55},
+            {"symbol": "issue_jwt", "file": "auth/tokens.py", "line": 12},
+        ],
+    },
+    {
+        "id": 3,
+        "repo_id": 1,
+        "name": "Payments",
+        "member_count": 31,
+        "human_verified": False,
+        "summary": "Payment provider integration, refund logic, and transaction records.",
+        "last_updated": "2026-05-01T08:02:00Z",
+        "members": [
+            {"symbol": "charge_card", "file": "payments/stripe.py", "line": 88},
+            {"symbol": "refund_order", "file": "payments/refunds.py", "line": 34},
+        ],
+    },
+    {
+        "id": 4,
+        "repo_id": 2,
+        "name": "User Management",
+        "member_count": 9,
+        "human_verified": False,
+        "summary": "User CRUD, role assignment, and profile updates.",
+        "last_updated": "2026-04-30T15:01:00Z",
+        "members": [
+            {"symbol": "update_profile", "file": "users/profile.py", "line": 22},
+        ],
+    },
+]
+
+_MOCK_USERS = [
+    {
+        "id": 1,
+        "email": "admin@example.com",
+        "role": "admin",
+        "created_at": "2026-01-10T09:00:00Z",
+        "last_login": "2026-05-01T14:23:00Z",
+        "must_change_password": False,
+    },
+    {
+        "id": 2,
+        "email": "dev@example.com",
+        "role": "user",
+        "created_at": "2026-02-15T10:00:00Z",
+        "last_login": "2026-04-28T11:00:00Z",
+        "must_change_password": True,
+    },
+]
+
+_MOCK_JOBS = [
+    {
+        "id": 10,
+        "repo_id": 1,
+        "repo_name": "shop-api",
+        "started_at": "2026-05-01T08:00:00Z",
+        "duration_s": 47,
+        "status": "success",
+        "trigger": "manual",
+        "error": None,
+    },
+    {
+        "id": 9,
+        "repo_id": 2,
+        "repo_name": "auth-service",
+        "started_at": "2026-04-30T15:00:00Z",
+        "duration_s": 23,
+        "status": "success",
+        "trigger": "manual",
+        "error": None,
+    },
+    {
+        "id": 8,
+        "repo_id": 1,
+        "repo_name": "shop-api",
+        "started_at": "2026-04-29T10:00:00Z",
+        "duration_s": 12,
+        "status": "failed",
+        "trigger": "webhook",
+        "error": "TreeSitter parse error on checkout/orders.py:88",
+    },
+    {
+        "id": 7,
+        "repo_id": 1,
+        "repo_name": "shop-api",
+        "started_at": "2026-04-28T09:00:00Z",
+        "duration_s": 50,
+        "status": "success",
+        "trigger": "manual",
+        "error": None,
+    },
+    {
+        "id": 6,
+        "repo_id": 2,
+        "repo_name": "auth-service",
+        "started_at": "2026-04-27T14:00:00Z",
+        "duration_s": 21,
+        "status": "success",
+        "trigger": "manual",
+        "error": None,
+    },
+]
+
+_mock_next_id = {"repo": 100, "user": 100}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _headers():
+    token = st.session_state.get("token")
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+def _handle_error(resp):
+    if resp.status_code == 401:
+        for key in list(st.session_state.keys()):
+            del st.session_state[key]
+        st.switch_page("Home.py")
+    elif resp.status_code == 403:
+        st.toast("Permission denied.", icon="❌")
+        st.stop()
+    elif resp.status_code >= 500:
+        st.toast(f"Server error ({resp.status_code}). Please try again.", icon="❌")
+        st.stop()
+
+
+# ---------------------------------------------------------------------------
+# Mock dispatch helpers
+# ---------------------------------------------------------------------------
+
+def _parse_id(path, prefix):
+    """Extract integer id from path like /admin/repos/42 given prefix /admin/repos/."""
+    try:
+        return int(path[len(prefix):].split("?")[0].split("/")[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def _mock_get(path):
+    global _MOCK_REPOS, _MOCK_DOMAINS, _MOCK_USERS, _MOCK_JOBS
+
+    parsed = urllib.parse.urlparse(path)
+    clean = parsed.path
+    qs = urllib.parse.parse_qs(parsed.query)
+
+    if clean == "/auth/me":
+        return _MOCK_USERS[0]
+
+    if clean == "/admin/repos":
+        return list(_MOCK_REPOS)
+
+    if clean.startswith("/admin/repos/"):
+        rid = _parse_id(clean, "/admin/repos/")
+        repo = next((r for r in _MOCK_REPOS if r["id"] == rid), None)
+        if repo:
+            return {
+                **repo,
+                "domains": [d for d in _MOCK_DOMAINS if d["repo_id"] == rid],
+                "recent_jobs": [j for j in _MOCK_JOBS if j["repo_id"] == rid][:20],
+            }
+        return {}
+
+    if clean.startswith("/admin/domains/"):
+        did = _parse_id(clean, "/admin/domains/")
+        return next((d for d in _MOCK_DOMAINS if d["id"] == did), {})
+
+    if clean == "/admin/domains" or clean.startswith("/admin/domains"):
+        repo_id_vals = qs.get("repo_id", [])
+        if repo_id_vals:
+            try:
+                rid = int(repo_id_vals[0])
+                if rid != 0:
+                    return [d for d in _MOCK_DOMAINS if d["repo_id"] == rid]
+            except ValueError:
+                pass
+        return list(_MOCK_DOMAINS)
+
+    if clean == "/admin/users":
+        return list(_MOCK_USERS)
+
+    if clean == "/admin/jobs" or clean.startswith("/admin/jobs"):
+        limit_vals = qs.get("limit", [])
+        limit = int(limit_vals[0]) if limit_vals else len(_MOCK_JOBS)
+        return _MOCK_JOBS[:limit]
+
+    if clean == "/admin/dashboard/stats":
+        return {
+            "total_repos": len(_MOCK_REPOS),
+            "total_domains": len(_MOCK_DOMAINS),
+            "total_users": len(_MOCK_USERS),
+            "jobs_24h": 2,
+        }
+
+    if clean == "/admin/health":
+        return {
+            "neo4j": "ok",
+            "llm": "ok",
+            "last_successful_index": "2026-05-01T08:00:00Z",
+        }
+
+    if clean == "/demo/repos":
+        return list(_MOCK_REPOS)
+
+    if clean.startswith("/demo/repos/") and clean.endswith("/domains"):
+        rid = _parse_id(clean, "/demo/repos/")
+        return [d for d in _MOCK_DOMAINS if d["repo_id"] == rid]
+
+    return {}
+
+
+def _mock_post(path, json_body):
+    global _MOCK_REPOS, _MOCK_USERS, _mock_next_id
+
+    parsed = urllib.parse.urlparse(path)
+    clean = parsed.path
+    body = json_body or {}
+
+    if clean == "/auth/logout":
+        return {}
+
+    if clean == "/auth/change-password":
+        return {"token": "mock.new.jwt.token"}
+
+    if clean == "/admin/repos":
+        url = body.get("github_url", "")
+        name = url.rstrip("/").split("/")[-1] if url else "new-repo"
+        new_repo = {
+            "id": _mock_next_id["repo"],
+            "github_url": url,
+            "name": name,
+            "branch": body.get("branch", "main"),
+            "status": "indexed",
+            "last_indexed_at": "2026-05-02T00:00:00Z",
+            "function_count": 0,
+            "domain_count": 0,
+        }
+        _mock_next_id["repo"] += 1
+        _MOCK_REPOS.append(new_repo)
+        return new_repo
+
+    if clean.startswith("/admin/repos/") and clean.endswith("/reindex"):
+        return {"status": "queued", "job_id": 99}
+
+    if clean.startswith("/admin/domains/") and clean.endswith("/regenerate"):
+        return {"status": "queued"}
+
+    if clean == "/admin/users":
+        new_user = {
+            "id": _mock_next_id["user"],
+            "email": body.get("email", "newuser@example.com"),
+            "role": body.get("role", "user"),
+            "created_at": "2026-05-02T00:00:00Z",
+            "last_login": None,
+            "must_change_password": True,
+            "temporary_password": "Temp@1234",
+        }
+        _mock_next_id["user"] += 1
+        _MOCK_USERS.append(new_user)
+        return new_user
+
+    if clean.startswith("/admin/users/") and clean.endswith("/reset-password"):
+        return {"temporary_password": "Reset@5678"}
+
+    if clean == "/demo/chat":
+        # Streaming handled separately via _mock_stream
+        return {}
+
+    return {}
+
+
+def _mock_patch(path, json_body):
+    global _MOCK_DOMAINS, _MOCK_USERS
+
+    parsed = urllib.parse.urlparse(path)
+    clean = parsed.path
+    body = json_body or {}
+
+    if clean.startswith("/admin/domains/"):
+        did = _parse_id(clean, "/admin/domains/")
+        for i, d in enumerate(_MOCK_DOMAINS):
+            if d["id"] == did:
+                _MOCK_DOMAINS[i] = {**d, **{k: v for k, v in body.items() if v is not None}}
+                return _MOCK_DOMAINS[i]
+        return {}
+
+    if clean.startswith("/admin/users/"):
+        uid = _parse_id(clean, "/admin/users/")
+        for i, u in enumerate(_MOCK_USERS):
+            if u["id"] == uid:
+                _MOCK_USERS[i] = {**u, **body}
+                return _MOCK_USERS[i]
+        return {}
+
+    return {}
+
+
+def _mock_delete(path):
+    global _MOCK_REPOS, _MOCK_USERS
+
+    parsed = urllib.parse.urlparse(path)
+    clean = parsed.path
+
+    if clean.startswith("/admin/repos/"):
+        rid = _parse_id(clean, "/admin/repos/")
+        _MOCK_REPOS[:] = [r for r in _MOCK_REPOS if r["id"] != rid]
+        return {}
+
+    if clean.startswith("/admin/users/"):
+        uid = _parse_id(clean, "/admin/users/")
+        _MOCK_USERS[:] = [u for u in _MOCK_USERS if u["id"] != uid]
+        return {}
+
+    return {}
+
+
+_MOCK_RESPONSES = {
+    "checkout": (
+        "get_domain_summary", "domain_id=1",
+        "Checkout domain: 23 members, human-verified.",
+        [
+            "The **Checkout** domain handles the full purchase lifecycle. ",
+            "Key entry point is `create_order` (checkout/orders.py:42), which ",
+            "validates the cart via `validate_cart`, applies discounts via ",
+            "`apply_discount` (pricing.py:142), then delegates to the Payments ",
+            "domain for charge processing. Post-purchase email triggers live in ",
+            "`send_confirmation` (checkout/notifications.py:89).",
+        ],
+    ),
+    "auth": (
+        "get_domain_summary", "domain_id=2",
+        "Auth domain: 14 members, not yet verified.",
+        [
+            "The **Auth** domain manages user identity and session lifecycle. ",
+            "`login_user` (auth/login.py:55) validates credentials, calls ",
+            "`issue_jwt` (auth/tokens.py:12) to mint a signed JWT, and stores ",
+            "the session. Password hashing uses bcrypt with a work factor of 12. ",
+            "Tokens expire after 24 h; refresh is not yet implemented.",
+        ],
+    ),
+    "payment": (
+        "get_domain_summary", "domain_id=3",
+        "Payments domain: 31 members, not yet verified.",
+        [
+            "The **Payments** domain wraps Stripe. `charge_card` ",
+            "(payments/stripe.py:88) is the primary entry point — it creates a ",
+            "PaymentIntent, confirms it, and records the transaction. Refunds ",
+            "go through `refund_order` (payments/refunds.py:34), which issues ",
+            "a partial or full Stripe refund and updates the order status.",
+        ],
+    ),
+    "discount": (
+        "get_code_context", "symbol_name=apply_discount",
+        "Found apply_discount in pricing.py:142 — 8 callers, 3 callees. Domain: Checkout.",
+        [
+            "The `apply_discount` function lives in the **Checkout** domain ",
+            "(pricing.py:142). It accepts a cart total and a discount code, ",
+            "validates the code against the promotions table, and applies a ",
+            "percentage reduction capped at 50%. It raises `InvalidDiscountError` ",
+            "if the code is expired or user-scoped but the user is not eligible.",
+        ],
+    ),
+    "user": (
+        "get_domain_summary", "domain_id=4",
+        "User Management domain: 9 members, not yet verified.",
+        [
+            "The **User Management** domain in auth-service handles user CRUD. ",
+            "`update_profile` (users/profile.py:22) accepts a partial update dict ",
+            "and validates each field via Pydantic before persisting. Role ",
+            "assignment is enforced server-side — the `role` field is ignored ",
+            "on self-updates and requires an admin token.",
+        ],
+    ),
+}
+
+_MOCK_DEFAULT_RESPONSE = (
+    "get_code_context", "symbol_name=<query>",
+    "Context retrieved — 12 nodes, 5 edges. Domain: Checkout.",
+    [
+        "Based on the codebase structure, the relevant logic spans the ",
+        "**Checkout** and **Payments** domains. The primary entry point is ",
+        "`create_order` (checkout/orders.py:42). Business rules are enforced ",
+        "at the service layer before any persistence calls are made. ",
+        "Let me know if you'd like me to drill into a specific function or domain.",
+    ],
+)
+
+
+def _mock_stream(path, json_body):
+    """Yields SSE-style event dicts with realistic delays for demo feel."""
+    if path != "/demo/chat":
+        return
+
+    msg = (json_body or {}).get("message", "").lower()
+    key = next(
+        (k for k in _MOCK_RESPONSES if k in msg),
+        None,
+    )
+    tool_name, tool_args, result_summary, tokens = (
+        _MOCK_RESPONSES[key] if key else _MOCK_DEFAULT_RESPONSE
+    )
+
+    yield {
+        "event": "tool_call",
+        "data": {"tool": tool_name, "args": tool_args, "status": "running"},
+    }
+    time.sleep(0.35)
+    yield {
+        "event": "tool_call",
+        "data": {"tool": tool_name, "status": "done", "result_summary": result_summary},
+    }
+    for token in tokens:
+        time.sleep(0.06)
+        yield {"event": "token", "data": {"delta": token}}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_MOCK_CREDENTIALS = {
+    ("user", "user"): {
+        "token": "mock.jwt.user",
+        "user_id": 2,
+        "email": "dev@example.com",
+        "role": "user",
+        "must_change_password": False,
+    },
+    ("admin", "admin"): {
+        "token": "mock.jwt.admin",
+        "user_id": 1,
+        "email": "admin@example.com",
+        "role": "admin",
+        "must_change_password": False,
+    },
+}
+
+
+def login(email: str, password: str) -> dict:
+    """Authenticate and return user dict. Raises ValueError on bad credentials."""
+    if MOCK_MODE:
+        result = _MOCK_CREDENTIALS.get((email.strip(), password))
+        if not result:
+            raise ValueError("Invalid credentials. Use user/user or admin/admin.")
+        return result
+    resp = requests.post(f"{BASE_URL}/auth/login", json={"email": email, "password": password})
+    if resp.status_code == 401:
+        raise ValueError("Invalid email or password.")
+    _handle_error(resp)
+    return resp.json()
+
+
+def get(path):
+    if MOCK_MODE:
+        return _mock_get(path)
+    resp = requests.get(f"{BASE_URL}{path}", headers=_headers())
+    _handle_error(resp)
+    return resp.json()
+
+
+def post(path, json=None):
+    if MOCK_MODE:
+        return _mock_post(path, json)
+    resp = requests.post(f"{BASE_URL}{path}", json=json, headers=_headers())
+    _handle_error(resp)
+    if resp.status_code == 204:
+        return {}
+    return resp.json()
+
+
+def patch(path, json=None):
+    if MOCK_MODE:
+        return _mock_patch(path, json)
+    resp = requests.patch(f"{BASE_URL}{path}", json=json, headers=_headers())
+    _handle_error(resp)
+    return resp.json()
+
+
+def delete(path):
+    if MOCK_MODE:
+        return _mock_delete(path)
+    resp = requests.delete(f"{BASE_URL}{path}", headers=_headers())
+    _handle_error(resp)
+    return {}
+
+
+def stream(path, json=None):
+    """Yields parsed SSE events as dicts: {"event": str, "data": dict}."""
+    if MOCK_MODE:
+        yield from _mock_stream(path, json)
+        return
+
+    with requests.post(
+        f"{BASE_URL}{path}",
+        json=json,
+        headers={**_headers(), "Accept": "text/event-stream"},
+        stream=True,
+        timeout=(5, 120),
+    ) as resp:
+        _handle_error(resp)
+        event_type = None
+        for raw_line in resp.iter_lines():
+            if not raw_line:
+                continue
+            line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
+            if line.startswith("event:"):
+                event_type = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                data_str = line[len("data:"):].strip()
+                try:
+                    data = _json.loads(data_str)
+                except ValueError:
+                    data = {"raw": data_str}
+                yield {"event": event_type, "data": data}
+                event_type = None

--- a/streamlit_app/lib/auth.py
+++ b/streamlit_app/lib/auth.py
@@ -1,0 +1,26 @@
+import streamlit as st
+
+
+def require_login():
+    if not st.session_state.get("token"):
+        # Home.py is the main script — st.switch_page("Home.py") is unsupported
+        # in Streamlit 1.37+. Rerun instead; Home.py will show the login form.
+        st.rerun()
+
+
+def require_admin():
+    require_login()
+    if st.session_state.get("role") != "admin":
+        st.error("Access denied. Admin privileges required.")
+        st.stop()
+
+
+def logout():
+    import lib.api_client as api
+    try:
+        api.post("/auth/logout")
+    except Exception:
+        pass
+    for key in list(st.session_state.keys()):
+        del st.session_state[key]
+    st.rerun()

--- a/streamlit_app/lib/prompts.py
+++ b/streamlit_app/lib/prompts.py
@@ -1,0 +1,33 @@
+DEVELOPER_PROMPT = """
+You are answering a software engineer. Include precise code references
+(file:line), exact function and class names, and use technical vocabulary
+freely. Be specific about types, parameters, and return values where relevant.
+Cite your sources from the structural context provided by the MCP tools.
+"""
+
+PRODUCT_PROMPT = """
+You are answering a product manager. Use plain English. Avoid code references,
+file paths, and technical jargon. Focus on the business behavior, user-facing
+implications, and edge cases. Provide example scenarios where helpful. Treat
+the underlying code structure as an implementation detail the reader does not
+need to see.
+"""
+
+LEGAL_PROMPT = """
+You are answering a compliance officer. Frame business rules as policy clauses.
+Cite the source files for traceability so any rule can be audited. Use formal,
+audit-ready language. Make it explicit when a rule has exceptions or when
+behavior depends on user attributes.
+"""
+
+PERSONA_PROMPTS = {
+    "developer": DEVELOPER_PROMPT,
+    "product": PRODUCT_PROMPT,
+    "legal": LEGAL_PROMPT,
+}
+
+PERSONA_LABELS = {
+    "developer": "Developer",
+    "product": "Product Manager",
+    "legal": "Legal / Compliance",
+}

--- a/streamlit_app/lib/styles.py
+++ b/streamlit_app/lib/styles.py
@@ -1,0 +1,539 @@
+import streamlit as st
+
+
+def apply_styles():
+    st.markdown("""
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@24,400,0,0&display=swap');
+
+    /* ══════════════════════════════════════════════════════════
+       BASE
+    ══════════════════════════════════════════════════════════ */
+    html, body, [class*="st-"], .stMarkdown, p, span, div,
+    label, button, input, textarea, select {
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+    }
+    #MainMenu, footer, .stDeployButton { visibility: hidden; }
+    .block-container { padding-top: 2.2rem !important; max-width: 1200px !important; }
+
+    /* ── Material Symbols Sharp variable font fix ─────────────
+       Without font-variation-settings the browser cannot render the glyphs
+       and falls back to plain text (e.g. "keyboard_double_arrow_left").
+       Setting the axes forces correct glyph rendering when the font loads.
+       The visibility:hidden fallback hides the text while the font is absent
+       and the ::after pseudo-element draws a CSS chevron instead.
+    ──────────────────────────────────────────────────────── */
+    .material-symbols-sharp {
+        font-family: 'Material Symbols Sharp' !important;
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24 !important;
+        -webkit-font-feature-settings: 'liga' !important;
+        font-feature-settings: 'liga' !important;
+        font-style: normal !important;
+        font-weight: normal !important;
+        text-rendering: optimizeLegibility !important;
+    }
+
+    /* ── Sidebar collapse / expand buttons ───────────────── */
+    [data-testid*="ollapsed"] .material-symbols-sharp {
+        font-size: 0 !important;
+        display: inline-block !important;
+        width: 20px !important; height: 20px !important;
+        position: relative !important;
+        visibility: visible !important;
+    }
+    [data-testid="collapsedControl"] .material-symbols-sharp::after {
+        content: '◀' !important;
+        font-size: 15px !important; font-family: sans-serif !important;
+        color: #8892a4 !important; line-height: 1 !important;
+        position: absolute !important;
+        top: 50% !important; left: 50% !important;
+        transform: translate(-50%, -50%) !important;
+    }
+    [data-testid="stSidebarCollapsedControl"] .material-symbols-sharp::after {
+        content: '▶' !important;
+        font-size: 15px !important; font-family: sans-serif !important;
+        color: #8892a4 !important; line-height: 1 !important;
+        position: absolute !important;
+        top: 50% !important; left: 50% !important;
+        transform: translate(-50%, -50%) !important;
+    }
+
+    /* ── Expander toggle arrows ───────────────────────────
+       Streamlit 1.37+ renders st.expander with div[data-testid] wrappers,
+       NOT native <details>/<summary>. Target the icon wrapper directly. */
+
+    /* Hide the raw "arrow_right" / "expand_more" icon-name text */
+    [data-testid="stExpanderToggleIcon"] .material-symbols-sharp,
+    [data-testid="stExpanderToggleIcon"] span {
+        font-size: 0 !important;
+        line-height: 0 !important;
+        color: transparent !important;
+        display: inline-block !important;
+        width: 16px !important; height: 16px !important;
+        position: relative !important;
+        overflow: hidden !important;
+    }
+
+    /* Collapsed state → ▸ */
+    [data-testid="stExpanderToggleIcon"] .material-symbols-sharp::after,
+    [data-testid="stExpanderToggleIcon"] span::after {
+        content: '▸' !important;
+        font-size: 13px !important;
+        font-family: sans-serif !important;
+        color: #8892a4 !important;
+        line-height: 1 !important;
+        overflow: visible !important;
+        position: absolute !important;
+        top: 50% !important; left: 50% !important;
+        transform: translate(-50%, -50%) !important;
+    }
+
+    /* Open state — Streamlit adds a CSS rotation to the icon wrapper */
+    [data-testid="stExpanderToggleIcon"][style*="rotate"] .material-symbols-sharp::after,
+    [data-testid="stExpanderToggleIcon"][style*="rotate"] span::after,
+    [aria-expanded="true"] [data-testid="stExpanderToggleIcon"] .material-symbols-sharp::after,
+    [aria-expanded="true"] [data-testid="stExpanderToggleIcon"] span::after {
+        content: '▾' !important;
+    }
+
+    /* Hide Streamlit's built-in prev/next page navigation arrows */
+    [data-testid="stPageLink"],
+    [data-testid="stPageNavigation"],
+    [data-testid="stBottomNavigation"],
+    button[kind="pageNavigation"],
+    .stPageLink { display: none !important; }
+
+    /* ══════════════════════════════════════════════════════════
+       SIDEBAR FLEX LAYOUT — footer sticks to bottom
+    ══════════════════════════════════════════════════════════ */
+    /* Make the sidebar's inner content block a flex column */
+    [data-testid="stSidebarContent"] > [data-testid="stVerticalBlock"] {
+        min-height: 100vh !important;
+        display: flex !important;
+        flex-direction: column !important;
+    }
+    /* Spacer grows to fill remaining space between nav and footer */
+    .cl-sidebar-spacer {
+        flex: 1 1 auto !important;
+        min-height: 24px !important;
+    }
+    /* Footer sits flush at bottom */
+    .cl-sidebar-footer {
+        border-top: 1px solid #1a2236;
+        padding-top: 10px;
+        padding-bottom: 4px;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       SIDEBAR
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stSidebar"] {
+        background: #080D1A !important;
+        border-right: 1px solid #1a2236 !important;
+    }
+    [data-testid="stSidebar"] > div:first-child { padding-top: 0 !important; }
+
+    /* Navigation links */
+    [data-testid="stSidebarNavLink"] {
+        border-radius: 8px !important;
+        margin: 2px 6px !important;
+        color: #8892a4 !important;
+        font-size: 14px !important;
+        font-weight: 500 !important;
+        transition: background 0.15s, color 0.15s !important;
+    }
+    [data-testid="stSidebarNavLink"]:hover {
+        background: rgba(99,102,241,.12) !important;
+        color: #c4cdff !important;
+    }
+    [data-testid="stSidebarNavLink"][aria-selected="true"] {
+        background: rgba(99,102,241,.2) !important;
+        color: #a5b4fc !important;
+        font-weight: 600 !important;
+    }
+
+    /* Sidebar section separators */
+    [data-testid="stSidebarNavSeparatorHeader"] {
+        font-size: 10px !important;
+        letter-spacing: .12em !important;
+        text-transform: uppercase !important;
+        color: #2d3748 !important;
+        font-weight: 700 !important;
+        padding-left: 18px !important;
+    }
+
+    /* Sidebar caption / small text */
+    [data-testid="stSidebar"] .stCaption,
+    [data-testid="stSidebar"] .stMarkdown p {
+        color: #4b5563 !important;
+        font-size: 12px !important;
+    }
+
+    /* Domain buttons in sidebar: plain text style */
+    [data-testid="stSidebar"] .stButton > button[kind="secondary"] {
+        background: transparent !important;
+        border: 1px solid #1a2236 !important;
+        color: #6b7280 !important;
+        font-size: 13px !important;
+        padding: 7px 12px !important;
+        text-align: left !important;
+        justify-content: flex-start !important;
+        border-radius: 7px !important;
+    }
+    [data-testid="stSidebar"] .stButton > button[kind="secondary"]:hover {
+        background: rgba(99,102,241,.1) !important;
+        border-color: rgba(99,102,241,.3) !important;
+        color: #a5b4fc !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       BUTTONS
+    ══════════════════════════════════════════════════════════ */
+    .stButton > button {
+        border-radius: 8px !important;
+        font-weight: 500 !important;
+        font-size: 14px !important;
+        font-family: 'Inter', sans-serif !important;
+        letter-spacing: -.01em !important;
+        transition: all .18s ease !important;
+        padding: 8px 16px !important;
+    }
+
+    /* Primary */
+    .stButton > button[kind="primary"] {
+        background: linear-gradient(135deg,#4f46e5 0%,#6366f1 100%) !important;
+        color: #fff !important;
+        border: none !important;
+        box-shadow: 0 1px 3px rgba(99,102,241,.35), 0 4px 12px rgba(99,102,241,.18) !important;
+    }
+    .stButton > button[kind="primary"]:hover {
+        background: linear-gradient(135deg,#4338ca 0%,#4f46e5 100%) !important;
+        box-shadow: 0 2px 8px rgba(99,102,241,.5), 0 6px 20px rgba(99,102,241,.25) !important;
+        transform: translateY(-1px) !important;
+    }
+    .stButton > button[kind="primary"]:active { transform: translateY(0) !important; }
+
+    /* Secondary */
+    .stButton > button[kind="secondary"] {
+        background: transparent !important;
+        border: 1px solid #2d3748 !important;
+        color: #8892a4 !important;
+    }
+    .stButton > button[kind="secondary"]:hover {
+        background: #1a2235 !important;
+        border-color: #4b5563 !important;
+        color: #e2e8f0 !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       INPUTS
+    ══════════════════════════════════════════════════════════ */
+    .stTextInput input,
+    .stTextArea textarea {
+        border-radius: 8px !important;
+        border: 1px solid #2d3748 !important;
+        background: #111827 !important;
+        color: #f1f5f9 !important;
+        font-size: 14px !important;
+        transition: border-color .2s, box-shadow .2s !important;
+    }
+    .stTextInput input:focus,
+    .stTextArea textarea:focus {
+        border-color: #6366f1 !important;
+        box-shadow: 0 0 0 3px rgba(99,102,241,.15) !important;
+        outline: none !important;
+    }
+    .stSelectbox > div[data-baseweb="select"] > div {
+        border-radius: 8px !important;
+        border: 1px solid #2d3748 !important;
+        background: #111827 !important;
+        color: #f1f5f9 !important;
+    }
+    /* Input and selectbox labels */
+    .stTextInput label,
+    .stTextArea label,
+    .stSelectbox label,
+    .stRadio label { color: #9ca3af !important; font-size: 13px !important; font-weight: 500 !important; }
+
+    /* Captions / small text */
+    .stCaption, [data-testid="stCaptionContainer"] p {
+        color: #6b7280 !important;
+        font-size: 12px !important;
+    }
+
+    /* Radio buttons */
+    .stRadio [data-baseweb="radio"] label { color: #d1d5db !important; font-size: 14px !important; }
+
+    /* Dataframe header */
+    [data-testid="stDataFrame"] th {
+        background: #1a2236 !important;
+        color: #9ca3af !important;
+        font-size: 12px !important;
+        font-weight: 600 !important;
+        letter-spacing: .05em !important;
+        text-transform: uppercase !important;
+    }
+    [data-testid="stDataFrame"] td { color: #d1d5db !important; font-size: 13px !important; }
+
+    /* ══════════════════════════════════════════════════════════
+       METRICS
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stMetric"] {
+        background: #111827 !important;
+        border: 1px solid #1a2236 !important;
+        border-radius: 14px !important;
+        padding: 20px 22px !important;
+        position: relative !important;
+        overflow: hidden !important;
+    }
+    [data-testid="stMetric"]::after {
+        content: '' !important;
+        position: absolute !important;
+        top: 0; left: 0; right: 0;
+        height: 2px !important;
+        background: linear-gradient(90deg,#6366f1,#818cf8) !important;
+    }
+    [data-testid="stMetricValue"] {
+        font-size: 2rem !important;
+        font-weight: 700 !important;
+        letter-spacing: -.03em !important;
+        color: #f9fafb !important;
+    }
+    [data-testid="stMetricLabel"] {
+        font-size: 11px !important;
+        font-weight: 600 !important;
+        letter-spacing: .08em !important;
+        text-transform: uppercase !important;
+        color: #4b5563 !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       CONTAINERS (border=True)
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stVerticalBlockBorderWrapper"] {
+        background: #111827 !important;
+        border: 1px solid #1a2236 !important;
+        border-radius: 14px !important;
+        padding: 4px !important;
+        transition: border-color .2s !important;
+    }
+    [data-testid="stVerticalBlockBorderWrapper"]:hover {
+        border-color: rgba(99,102,241,.35) !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       DATAFRAME
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stDataFrame"] {
+        border-radius: 12px !important;
+        overflow: hidden !important;
+        border: 1px solid #1a2236 !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       CHAT
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stChatMessage"] {
+        background: #111827 !important;
+        border: 1px solid #1a2236 !important;
+        border-radius: 14px !important;
+        padding: 16px 20px !important;
+        margin: 5px 0 !important;
+    }
+
+    /* Chat input box */
+    [data-testid="stChatInput"] {
+        border-top: 1px solid #1a2236 !important;
+        background: #0f172a !important;
+        padding: 12px 0 !important;
+    }
+    [data-testid="stChatInput"] textarea {
+        border-radius: 12px !important;
+        border: 1px solid #2d3748 !important;
+        background: #111827 !important;
+        color: #f1f5f9 !important;
+        font-size: 15px !important;
+        padding: 14px 16px !important;
+        transition: border-color .2s, box-shadow .2s !important;
+    }
+    [data-testid="stChatInput"] textarea:focus {
+        border-color: #6366f1 !important;
+        box-shadow: 0 0 0 3px rgba(99,102,241,.12) !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       FORMS
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stForm"] {
+        border: 1px solid #1a2236 !important;
+        border-radius: 14px !important;
+        background: #111827 !important;
+        padding: 20px !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       EXPANDER
+    ══════════════════════════════════════════════════════════ */
+    [data-testid="stExpander"] {
+        border: 1px solid #1a2236 !important;
+        border-radius: 10px !important;
+        background: #111827 !important;
+    }
+    [data-testid="stExpander"] summary {
+        font-size: 14px !important;
+        font-weight: 500 !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       MISC
+    ══════════════════════════════════════════════════════════ */
+    /* Hide "Press Enter to submit" hint inside forms */
+    [data-testid="InputInstructions"] { display: none !important; }
+
+    hr { border-color: #1a2236 !important; margin: 16px 0 !important; }
+
+    [data-testid="stAlertContainer"] { border-radius: 10px !important; }
+
+    /* Toast */
+    [data-testid="stToast"] {
+        border-radius: 10px !important;
+        border: 1px solid #1a2236 !important;
+        background: #111827 !important;
+    }
+
+    /* Dialog */
+    [data-testid="stModal"] > div > div {
+        background: #111827 !important;
+        border: 1px solid #1a2236 !important;
+        border-radius: 16px !important;
+    }
+
+    /* ══════════════════════════════════════════════════════════
+       CUSTOM COMPONENTS (HTML injected via st.markdown)
+    ══════════════════════════════════════════════════════════ */
+
+    /* Page header */
+    .cl-page-header { margin-bottom: 24px; }
+    .cl-page-header h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        letter-spacing: -.03em;
+        margin: 0 0 4px;
+        background: linear-gradient(135deg,#f9fafb 40%,#818cf8 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+    }
+    .cl-page-header p { color: #4b5563; font-size: 14px; margin: 0; }
+
+    /* Sidebar brand */
+    .cl-brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 18px 14px 14px;
+        border-bottom: 1px solid #1a2236;
+        margin-bottom: 6px;
+    }
+    .cl-brand-icon {
+        width: 30px; height: 30px;
+        background: linear-gradient(135deg,#4f46e5,#818cf8);
+        border-radius: 8px;
+        display: flex; align-items: center; justify-content: center;
+        font-size: 15px; flex-shrink: 0;
+    }
+    .cl-brand-name {
+        font-size: 15px; font-weight: 700;
+        letter-spacing: -.02em;
+        color: #f9fafb !important;
+    }
+
+    /* User info */
+    .cl-user-info {
+        padding: 10px 12px;
+        background: #0d1117;
+        border: 1px solid #1a2236;
+        border-radius: 10px;
+        margin: 2px 4px;
+    }
+    .cl-user-email { font-size: 12px; color: #6b7280; font-weight: 500; }
+    .cl-role-badge {
+        display: inline-block;
+        background: rgba(99,102,241,.18);
+        color: #818cf8;
+        border-radius: 4px;
+        padding: 1px 7px;
+        font-size: 10px; font-weight: 700;
+        letter-spacing: .06em;
+        text-transform: uppercase;
+        margin-top: 3px;
+    }
+
+    /* Chat hero (empty state) */
+    .cl-chat-hero {
+        text-align: center;
+        padding: 52px 20px 36px;
+    }
+    .cl-chat-hero-icon {
+        width: 60px; height: 60px;
+        background: linear-gradient(135deg,#4f46e5,#818cf8);
+        border-radius: 16px;
+        display: flex; align-items: center; justify-content: center;
+        font-size: 26px;
+        margin: 0 auto 18px;
+        box-shadow: 0 8px 28px rgba(99,102,241,.35);
+    }
+    .cl-chat-hero h2 {
+        font-size: 1.75rem; font-weight: 700;
+        letter-spacing: -.03em;
+        color: #f9fafb; margin: 0 0 10px;
+    }
+    .cl-chat-hero p { color: #4b5563; font-size: 15px; line-height: 1.6; margin: 0; }
+
+    /* Login page */
+    .cl-login-logo {
+        width: 52px; height: 52px;
+        background: linear-gradient(135deg,#4f46e5,#818cf8);
+        border-radius: 14px;
+        display: flex; align-items: center; justify-content: center;
+        font-size: 24px;
+        margin: 0 auto 16px;
+        box-shadow: 0 8px 28px rgba(99,102,241,.4);
+    }
+    .cl-login-title {
+        font-size: 2.1rem; font-weight: 800;
+        letter-spacing: -.04em;
+        background: linear-gradient(135deg,#f9fafb 40%,#818cf8 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        text-align: center; margin-bottom: 6px;
+    }
+    .cl-login-sub { color: #4b5563; font-size: 15px; text-align: center; margin-bottom: 28px; }
+    .cl-login-hint { text-align: center; margin-top: 14px; font-size: 13px; color: #374151; }
+    .cl-login-hint code {
+        background: #1e293b;
+        border: 1px solid #2d3748;
+        border-radius: 5px;
+        padding: 1px 6px;
+        font-family: 'SF Mono','Fira Code',monospace;
+        color: #818cf8; font-size: 12px;
+    }
+
+    /* Tool call lines in chat */
+    .cl-tool-call {
+        font-size: 13px; color: #4b5563;
+        padding: 4px 0 2px;
+        border-left: 2px solid #374151;
+        padding-left: 10px;
+        margin: 4px 0;
+    }
+    .cl-tool-done {
+        font-size: 13px; color: #34d399;
+        padding: 2px 0 6px;
+        border-left: 2px solid #34d399;
+        padding-left: 10px;
+        margin: 2px 0;
+    }
+    </style>
+    """, unsafe_allow_html=True)

--- a/streamlit_app/pages/1_Ask.py
+++ b/streamlit_app/pages/1_Ask.py
@@ -1,0 +1,179 @@
+import streamlit as st
+
+import lib.api_client as api
+from lib.auth import require_login
+from lib.prompts import PERSONA_LABELS
+
+require_login()
+
+# ---------------------------------------------------------------------------
+# Session init
+# ---------------------------------------------------------------------------
+if "messages"         not in st.session_state: st.session_state["messages"]         = []
+if "persona"          not in st.session_state: st.session_state["persona"]           = "developer"
+if "selected_repo_id" not in st.session_state: st.session_state["selected_repo_id"] = None
+if "_last_repo_id"    not in st.session_state: st.session_state["_last_repo_id"]     = None
+
+# ---------------------------------------------------------------------------
+# Sidebar
+# ---------------------------------------------------------------------------
+with st.sidebar:
+    with st.spinner(""):
+        repos = api.get("/demo/repos")
+
+    if not repos:
+        st.warning("No repositories indexed.")
+        if st.session_state.get("role") == "admin":
+            if st.button("Go to Admin Panel", use_container_width=True):
+                st.switch_page("pages/2_Admin_Dashboard.py")
+        st.stop()
+
+    st.markdown("---")
+
+    # ── Repo selector ─────────────────────────────────────────
+    if len(repos) > 1:
+        repo_map = {r["id"]: r["name"] for r in repos}
+        new_repo_id = st.selectbox(
+            "Repository",
+            options=list(repo_map.keys()),
+            format_func=lambda x: repo_map[x],
+        )
+    else:
+        new_repo_id = repos[0]["id"]
+        st.markdown(f"**Repository:** {repos[0]['name']}")
+
+    if st.session_state["_last_repo_id"] is not None and new_repo_id != st.session_state["_last_repo_id"]:
+        st.session_state["messages"] = []
+    st.session_state["selected_repo_id"] = new_repo_id
+    st.session_state["_last_repo_id"]    = new_repo_id
+
+    # ── Persona ───────────────────────────────────────────────
+    st.write("")
+    st.caption("Persona")
+    _PERSONA_SHORT = {"developer": "Dev", "product": "PM", "legal": "Legal"}
+    p1, p2, p3 = st.columns(3)
+    for col, (key, short) in zip([p1, p2, p3], _PERSONA_SHORT.items()):
+        active = st.session_state["persona"] == key
+        if col.button(short, key=f"p_{key}", type="primary" if active else "secondary", use_container_width=True):
+            st.session_state["persona"] = key
+            st.rerun()
+
+    tooltip = {"developer": "File paths, function names, types", "product": "Business behavior, plain English", "legal": "Policy clauses, audit-ready"}
+    st.caption(f"*{tooltip[st.session_state['persona']]}*")
+
+    # ── New conversation ──────────────────────────────────────
+    st.write("")
+    if st.button("＋ New Conversation", use_container_width=True, type="secondary"):
+        st.session_state["messages"] = []
+        st.rerun()
+
+    # ── Domain browser ────────────────────────────────────────
+    st.markdown("---")
+    st.caption("Domains")
+
+    with st.spinner(""):
+        domains = api.get(f"/demo/repos/{new_repo_id}/domains")
+    _ICONS = ["📦", "🔐", "💳", "👥", "⚙️", "🧩", "📡"]
+    for i, domain in enumerate(domains):
+        icon  = _ICONS[i % len(_ICONS)]
+        label = f"{icon}  {domain['name']}  ({domain.get('member_count', 0)})"
+        if st.button(label, key=f"d_{domain['id']}", use_container_width=True):
+            prompt = f"Tell me about the {domain['name']} domain."
+            st.session_state["messages"].append({"role": "user", "content": prompt})
+            st.session_state["_pending_prompt"] = prompt
+            st.rerun()
+
+# ---------------------------------------------------------------------------
+# Chat processing
+# ---------------------------------------------------------------------------
+def _process_chat(user_prompt: str):
+    payload = {
+        "message":  user_prompt,
+        "repo_id":  st.session_state.get("selected_repo_id"),
+        "persona":  st.session_state.get("persona", "developer"),
+        "history":  st.session_state["messages"][:-1],
+    }
+    assistant_text = ""
+    with st.chat_message("assistant"):
+        placeholder = st.empty()
+        placeholder.markdown("▌")
+        try:
+            for event in api.stream("/demo/chat", json=payload):
+                etype = event.get("event")
+                data  = event.get("data", {})
+                if etype == "tool_call":
+                    if data.get("status") == "running":
+                        st.markdown(f"<div class='cl-tool-call'>🔍 &nbsp;<code>{data.get('tool','')}</code></div>", unsafe_allow_html=True)
+                    elif data.get("status") == "done":
+                        st.markdown(f"<div class='cl-tool-done'>✅ &nbsp;{data.get('result_summary','Done')}</div>", unsafe_allow_html=True)
+                elif etype == "token":
+                    assistant_text += data.get("delta", "")
+                    placeholder.markdown(assistant_text + "▌")
+        except Exception as e:
+            err = str(e).lower()
+            if "rate" in err or "429" in err or "quota" in err:
+                assistant_text = "⏳ Sending messages too quickly. Please wait ~30 seconds."
+            elif "timeout" in err or "mcp" in err or "tool" in err:
+                assistant_text = "❌ MCP tool timeout. Please try again."
+            else:
+                assistant_text = f"❌ Something went wrong. Please try again."
+        placeholder.markdown(assistant_text)
+    st.session_state["messages"].append({"role": "assistant", "content": assistant_text})
+
+# ---------------------------------------------------------------------------
+# Main area
+# ---------------------------------------------------------------------------
+st.markdown("""
+<div class="cl-page-header">
+    <h1>Ask CodeLens</h1>
+    <p>Ask anything about your codebase — structure, business rules, domain logic.</p>
+</div>
+""", unsafe_allow_html=True)
+
+# Render history
+for msg in st.session_state["messages"]:
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+
+# Empty state
+if not st.session_state["messages"]:
+    st.markdown("""
+    <div class="cl-chat-hero">
+        <div class="cl-chat-hero-icon">◈</div>
+        <h2>What would you like to know?</h2>
+        <p>Ask about a function, explore a business domain,<br>or understand the rules behind any feature.</p>
+    </div>
+    """, unsafe_allow_html=True)
+
+    st.write("")
+    _suggestions = [
+        ("🔍", "Explain a function",       "How does apply_discount work?"),
+        ("🗂️", "Explore a domain",          "Tell me about the Checkout domain."),
+        ("⚖️", "Understand business rules", "What are the discount rules in Payments?"),
+    ]
+    c1, c2, c3 = st.columns(3, gap="medium")
+    for col, (icon, title, prompt) in zip([c1, c2, c3], _suggestions):
+        with col:
+            with st.container(border=True):
+                st.markdown(f"<div style='font-size:1.6rem;margin-bottom:10px'>{icon}</div>", unsafe_allow_html=True)
+                st.markdown(f"**{title}**")
+                st.caption(f"*{prompt}*")
+                st.write("")
+                if st.button("Try this →", key=f"s_{hash(prompt)}", use_container_width=True):
+                    st.session_state["messages"].append({"role": "user", "content": prompt})
+                    st.session_state["_pending_prompt"] = prompt
+                    st.rerun()
+
+# Pending prompt (from domain buttons or suggestion cards)
+if st.session_state.get("_pending_prompt"):
+    pending = st.session_state.pop("_pending_prompt")
+    with st.chat_message("user"):
+        st.markdown(pending)
+    _process_chat(pending)
+
+# Live input
+if prompt := st.chat_input("Ask about your codebase…"):
+    st.session_state["messages"].append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+    _process_chat(prompt)

--- a/streamlit_app/pages/2_Admin_Dashboard.py
+++ b/streamlit_app/pages/2_Admin_Dashboard.py
@@ -1,0 +1,139 @@
+from datetime import datetime, timezone
+
+import streamlit as st
+
+import lib.api_client as api
+from lib.auth import require_admin
+
+require_admin()
+
+import re as _re
+
+
+def _fmt_dt(iso: str) -> str:
+    """ISO 8601 → '01 May 2026  08:00'"""
+    if not iso:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%d %b %Y  %H:%M")
+    except Exception:
+        return iso
+
+
+def _relative_time(iso: str) -> str:
+    """Return a human-readable relative time string from an ISO 8601 timestamp."""
+    if not iso:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        delta = datetime.now(timezone.utc) - dt
+        s = int(delta.total_seconds())
+        if s < 60:
+            return "just now"
+        if s < 3600:
+            m = s // 60
+            return f"{m} minute{'s' if m != 1 else ''} ago"
+        if s < 86400:
+            h = s // 3600
+            return f"{h} hour{'s' if h != 1 else ''} ago"
+        d = s // 86400
+        return f"{d} day{'s' if d != 1 else ''} ago"
+    except Exception:
+        return iso
+
+_STATUS_ICONS = {
+    "success": "✅",
+    "failed":  "❌",
+    "running": "🔄",
+    "indexed": "✅",
+    "indexing":"🔄",
+}
+
+
+@st.dialog("Add Repository")
+def _add_repo_dialog():
+    with st.form("add_repo_form_dash"):
+        github_url = st.text_input("GitHub URL", placeholder="https://github.com/owner/repo")
+        branch = st.text_input("Branch", value="main")
+        submitted = st.form_submit_button("Add Repo", type="primary")
+    if submitted:
+        if not _re.match(r"https://github\.com/[\w\-]+/[\w\-\.]+", github_url):
+            st.error("Enter a valid GitHub URL.")
+            return
+        with st.spinner("Adding…"):
+            api.post("/admin/repos", json={"github_url": github_url, "branch": branch})
+        st.toast("Repository added.", icon="✓")
+        st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Page
+# ---------------------------------------------------------------------------
+
+st.markdown("""
+<div class="cl-page-header">
+    <h1>Dashboard</h1>
+    <p>System overview and recent activity</p>
+</div>
+""", unsafe_allow_html=True)
+
+with st.spinner(""):
+    stats  = api.get("/admin/dashboard/stats")
+    jobs   = api.get("/admin/jobs?limit=5")
+    health = api.get("/admin/health")
+
+# ── KPIs ──────────────────────────────────────────────────────────────────
+c1, c2, c3, c4 = st.columns(4)
+c1.metric("Repositories",   stats.get("total_repos", 0))
+c2.metric("Domains",        stats.get("total_domains", 0))
+c3.metric("Users",          stats.get("total_users", 0))
+c4.metric("Jobs (24 h)",    stats.get("jobs_24h", 0))
+
+st.write("")
+
+# ── Recent Jobs ────────────────────────────────────────────────────────────
+left, right = st.columns([2, 1], gap="large")
+
+with left:
+    st.markdown("#### Recent Indexing Jobs")
+    if not jobs:
+        st.info("No indexing jobs have run yet.")
+    else:
+        rows = [
+            {
+                "Status":      _STATUS_ICONS.get(j.get("status", ""), j.get("status", "")),
+                "Repository":  j.get("repo_name", "—"),
+                "Started":     _fmt_dt(j.get("started_at", "")),
+                "Duration":    f"{j.get('duration_s', '—')} s",
+                "Trigger":     j.get("trigger", "—"),
+            }
+            for j in jobs
+        ]
+        st.dataframe(rows, use_container_width=True, hide_index=True)
+        for j in jobs:
+            if j.get("status") == "failed" and j.get("error"):
+                with st.expander(f"❌  {j.get('repo_name')}  ·  {_fmt_dt(j.get('started_at', ''))}"):
+                    st.code(j["error"])
+
+# ── Health + Quick Actions ─────────────────────────────────────────────────
+with right:
+    st.markdown("#### System Health")
+    neo4j = health.get("neo4j", "unknown")
+    llm   = health.get("llm", "unknown")
+    last  = health.get("last_successful_index", "—")
+
+    with st.container(border=True):
+        hc1, hc2 = st.columns(2)
+        hc1.metric("Neo4j",        "✅ OK"   if neo4j == "ok" else f"❌ {neo4j}")
+        hc2.metric("LLM (Gemini)", "✅ OK"   if llm   == "ok" else f"⚠️ {llm}")
+        st.caption(f"Last successful index: **{_relative_time(last)}**")
+
+    st.write("")
+    st.markdown("#### Quick Actions")
+    if st.button("＋ Add Repository", type="primary", use_container_width=True):
+        _add_repo_dialog()
+    if st.button("→ Manage Repositories", use_container_width=True):
+        st.switch_page("pages/3_Admin_Repos.py")
+    if st.button("→ Manage Users", use_container_width=True):
+        st.switch_page("pages/5_Admin_Users.py")

--- a/streamlit_app/pages/3_Admin_Repos.py
+++ b/streamlit_app/pages/3_Admin_Repos.py
@@ -1,0 +1,182 @@
+import re
+from datetime import datetime, timezone
+
+import streamlit as st
+
+
+def _fmt_dt(iso: str) -> str:
+    if not iso:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%d %b %Y  %H:%M")
+    except Exception:
+        return iso
+
+import lib.api_client as api
+from lib.auth import require_admin
+
+require_admin()
+
+_STATUS_ICONS = {"indexed": "✅", "indexing": "🔄", "failed": "❌"}
+
+if "selected_repo_id" not in st.session_state:
+    st.session_state["selected_repo_id"] = None
+
+
+# ---------------------------------------------------------------------------
+# Dialogs
+# ---------------------------------------------------------------------------
+
+@st.dialog("Add Repository")
+def _add_repo_dialog():
+    with st.form("add_repo_form"):
+        github_url = st.text_input("GitHub URL", placeholder="https://github.com/owner/repo")
+        branch = st.text_input("Branch", value="main")
+        submitted = st.form_submit_button("Add Repo", type="primary")
+    if submitted:
+        if not re.match(r"https://github\.com/[\w\-]+/[\w\-\.]+", github_url):
+            st.error("Enter a valid GitHub URL.")
+            return
+        with st.spinner("Adding…"):
+            api.post("/admin/repos", json={"github_url": github_url, "branch": branch})
+        st.toast("Repository added.", icon="✓")
+        st.rerun()
+
+
+@st.dialog("Confirm Delete")
+def _confirm_delete_repo_dialog():
+    repo = st.session_state.get("_delete_repo_target", {})
+    st.markdown(f"Delete **{repo.get('name')}**?")
+    st.caption(
+        f"This permanently removes **{repo.get('function_count', 0)}** functions "
+        f"and **{repo.get('domain_count', 0)}** domain clusters."
+    )
+    st.write("")
+    c1, c2 = st.columns(2)
+    if c1.button("Cancel", use_container_width=True):
+        st.session_state.pop("_delete_repo_target", None)
+        st.rerun()
+    if c2.button("Delete", type="primary", use_container_width=True):
+        with st.spinner("Deleting…"):
+            api.delete(f"/admin/repos/{repo['id']}")
+        st.session_state.pop("_delete_repo_target", None)
+        st.toast(f"'{repo['name']}' deleted.", icon="✓")
+        st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+def _render_list_view():
+    hdr, btn_col = st.columns([5, 1])
+    hdr.markdown("""
+    <div class="cl-page-header">
+        <h1>Repositories</h1>
+        <p>Manage indexed codebases</p>
+    </div>
+    """, unsafe_allow_html=True)
+    with btn_col:
+        st.write("")
+        st.write("")
+        if st.button("＋ Add Repo", type="primary", use_container_width=True):
+            _add_repo_dialog()
+
+    with st.spinner(""):
+        repos = api.get("/admin/repos")
+
+    if not repos:
+        st.info("No repositories added yet.")
+        if st.button("＋ Add your first repository", type="primary"):
+            _add_repo_dialog()
+        return
+
+    for repo in repos:
+        with st.container(border=True):
+            top, actions = st.columns([5, 2])
+            with top:
+                status_icon = _STATUS_ICONS.get(repo.get("status", ""), "")
+                st.markdown(
+                    f"**{repo['name']}** &nbsp;`{repo['branch']}`&nbsp;&nbsp;"
+                    f"{status_icon} &nbsp;"
+                    f"<span style='color:#4B5563;font-size:13px'>"
+                    f"{repo.get('function_count',0)} fns · "
+                    f"{repo.get('domain_count',0)} domains · "
+                    f"indexed {_fmt_dt(repo.get('last_indexed_at',''))}</span>",
+                    unsafe_allow_html=True,
+                )
+            with actions:
+                a1, a2, a3 = st.columns(3)
+                if a1.button("View", key=f"view_{repo['id']}", use_container_width=True):
+                    st.session_state["selected_repo_id"] = repo["id"]
+                    st.rerun()
+                if a2.button("Index", key=f"reindex_{repo['id']}", use_container_width=True):
+                    with st.spinner("Queuing…"):
+                        api.post(f"/admin/repos/{repo['id']}/reindex")
+                    st.toast("Re-indexing started.", icon="✓")
+                if a3.button("Delete", key=f"delete_{repo['id']}", use_container_width=True):
+                    st.session_state["_delete_repo_target"] = repo
+                    _confirm_delete_repo_dialog()
+
+
+def _render_detail_view(repo_id):
+    if st.button("← Back"):
+        st.session_state["selected_repo_id"] = None
+        st.rerun()
+
+    with st.spinner(""):
+        repo = api.get(f"/admin/repos/{repo_id}")
+
+    if not repo:
+        st.error("Repository not found.")
+        return
+
+    st.markdown(f"""
+    <div class="cl-page-header">
+        <h1>{repo.get('name','Repository')}</h1>
+        <p>{repo.get('github_url','')}</p>
+    </div>
+    """, unsafe_allow_html=True)
+
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric("Status",    _STATUS_ICONS.get(repo.get("status",""), repo.get("status","")))
+    c2.metric("Branch",    repo.get("branch","—"))
+    c3.metric("Functions", repo.get("function_count", 0))
+    c4.metric("Domains",   repo.get("domain_count", 0))
+
+    st.write("")
+    left, right = st.columns(2, gap="large")
+
+    with left:
+        st.markdown("#### Domains")
+        domains = repo.get("domains", [])
+        if not domains:
+            st.caption("No domains discovered yet.")
+        else:
+            for d in domains:
+                verified = " ✅" if d.get("human_verified") else ""
+                st.write(f"- **{d['name']}**{verified} — {d.get('member_count',0)} members")
+
+    with right:
+        st.markdown("#### Recent Jobs")
+        jobs = repo.get("recent_jobs", [])
+        if not jobs:
+            st.caption("No jobs yet.")
+        else:
+            for j in jobs:
+                icon = "✅" if j.get("status") == "success" else "❌"
+                st.write(f"{icon} {_fmt_dt(j.get('started_at',''))} · {j.get('duration_s',0)} s")
+                if j.get("error"):
+                    with st.expander("Error detail"):
+                        st.code(j["error"])
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+if st.session_state["selected_repo_id"] is None:
+    _render_list_view()
+else:
+    _render_detail_view(st.session_state["selected_repo_id"])

--- a/streamlit_app/pages/4_Admin_Domains.py
+++ b/streamlit_app/pages/4_Admin_Domains.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timezone
+
+import streamlit as st
+
+import lib.api_client as api
+from lib.auth import require_admin
+
+
+def _relative_time(iso: str) -> str:
+    if not iso:
+        return ""
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        delta = datetime.now(timezone.utc) - dt
+        s = int(delta.total_seconds())
+        if s < 60:
+            return "just now"
+        if s < 3600:
+            m = s // 60
+            return f"{m}m ago"
+        if s < 86400:
+            return f"{s // 3600}h ago"
+        return f"{s // 86400}d ago"
+    except Exception:
+        return iso
+
+require_admin()
+
+if "selected_domain_id" not in st.session_state:
+    st.session_state["selected_domain_id"] = None
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+def _render_list_view():
+    st.markdown("""
+    <div class="cl-page-header">
+        <h1>Domains</h1>
+        <p>Review and edit AI-generated domain summaries</p>
+    </div>
+    """, unsafe_allow_html=True)
+
+    with st.spinner(""):
+        repos = api.get("/admin/repos")
+
+    repo_options = {0: "All Repositories"}
+    for r in repos:
+        repo_options[r["id"]] = r["name"]
+
+    selected_repo_id = st.selectbox(
+        "Filter by repository",
+        options=list(repo_options.keys()),
+        format_func=lambda x: repo_options[x],
+        label_visibility="collapsed",
+    )
+
+    query = (
+        f"/admin/domains?repo_id={selected_repo_id}"
+        if selected_repo_id != 0
+        else "/admin/domains"
+    )
+    with st.spinner(""):
+        domains = api.get(query)
+
+    if not domains:
+        st.info("No domains found. Index a repository to discover domains.")
+        return
+
+    st.write("")
+    for domain in domains:
+        with st.container(border=True):
+            info_col, btn_col = st.columns([5, 1])
+            with info_col:
+                verified = "✅ Verified" if domain.get("human_verified") else ""
+                updated = _relative_time(domain.get("last_updated", ""))
+                st.markdown(
+                    f"**{domain['name']}** &nbsp;"
+                    f"<span style='color:#4B5563;font-size:13px'>"
+                    f"{domain.get('member_count',0)} members"
+                    f"{' · ' + verified if verified else ''}"
+                    f"{' · Updated ' + updated if updated else ''}"
+                    f"</span>",
+                    unsafe_allow_html=True,
+                )
+                st.caption(
+                    (domain.get("summary", "") or "")[:120] + ("…" if len(domain.get("summary","")) > 120 else "")
+                )
+            with btn_col:
+                if st.button("Edit →", key=f"domain_{domain['id']}", use_container_width=True):
+                    st.session_state["selected_domain_id"] = domain["id"]
+                    st.rerun()
+
+
+def _render_detail_view(domain_id):
+    if st.button("← Back"):
+        st.session_state["selected_domain_id"] = None
+        st.rerun()
+
+    with st.spinner(""):
+        domain = api.get(f"/admin/domains/{domain_id}")
+
+    if not domain:
+        st.error("Domain not found.")
+        return
+
+    st.markdown(f"""
+    <div class="cl-page-header">
+        <h1>{domain.get('name','Domain')}</h1>
+        <p>{domain.get('member_count',0)} members · {"✅ Human verified" if domain.get('human_verified') else "Not yet verified"}</p>
+    </div>
+    """, unsafe_allow_html=True)
+
+    left, right = st.columns([3, 2], gap="large")
+
+    with left:
+        summary = st.text_area(
+            "Summary",
+            value=domain.get("summary", ""),
+            height=160,
+            help="Plain-English description of what this domain does.",
+        )
+        verified = st.checkbox("Mark as Human Verified", value=domain.get("human_verified", False))
+        st.write("")
+        save_col, regen_col = st.columns(2)
+        if save_col.button("Save Changes", type="primary", use_container_width=True):
+            with st.spinner("Saving…"):
+                api.patch(
+                    f"/admin/domains/{domain_id}",
+                    json={"summary": summary, "human_verified": verified},
+                )
+            st.toast("Domain updated.", icon="✓")
+        if regen_col.button("Re-generate with LLM", use_container_width=True):
+            with st.spinner("Queuing…"):
+                api.post(f"/admin/domains/{domain_id}/regenerate")
+            st.toast("Regeneration queued. Ready in ~30 s.", icon="✓")
+
+    with right:
+        members = domain.get("members", [])
+        st.markdown(f"#### Members ({len(members)})")
+        if not members:
+            st.caption("No members listed.")
+        else:
+            for m in members:
+                st.write(f"`{m['symbol']}` — `{m['file']}:{m['line']}`")
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+if st.session_state["selected_domain_id"] is None:
+    _render_list_view()
+else:
+    _render_detail_view(st.session_state["selected_domain_id"])

--- a/streamlit_app/pages/5_Admin_Users.py
+++ b/streamlit_app/pages/5_Admin_Users.py
@@ -1,0 +1,142 @@
+import streamlit as st
+
+import lib.api_client as api
+from lib.auth import require_admin
+
+require_admin()
+
+
+# ---------------------------------------------------------------------------
+# Dialogs
+# ---------------------------------------------------------------------------
+
+@st.dialog("Add User")
+def _add_user_dialog():
+    if "new_user_temp_password" not in st.session_state:
+        with st.form("add_user_form"):
+            email = st.text_input("Email address")
+            role = st.radio("Role", ["user", "admin"], horizontal=True)
+            submitted = st.form_submit_button("Create User", type="primary")
+        if submitted:
+            if not email or "@" not in email:
+                st.error("Enter a valid email address.")
+                return
+            with st.spinner("Creating…"):
+                result = api.post("/admin/users", json={"email": email, "role": role})
+            st.session_state["new_user_temp_password"] = result.get("temporary_password", "")
+            st.rerun()
+    else:
+        temp_pw = st.session_state["new_user_temp_password"]
+        st.success("User created.")
+        st.warning("⚠️ This password is shown **once only**. Copy it now.")
+        st.code(temp_pw, language=None)
+        if st.button("Done", type="primary", use_container_width=True):
+            del st.session_state["new_user_temp_password"]
+            st.rerun()
+
+
+@st.dialog("Reset Password")
+def _reset_password_dialog():
+    user = st.session_state.get("_reset_password_target", {})
+    if "reset_temp_password" not in st.session_state:
+        st.write(f"Reset password for **{user.get('email')}**?")
+        c1, c2 = st.columns(2)
+        if c1.button("Cancel", use_container_width=True):
+            st.session_state.pop("_reset_password_target", None)
+            st.rerun()
+        if c2.button("Reset", type="primary", use_container_width=True):
+            with st.spinner("Resetting…"):
+                result = api.post(f"/admin/users/{user['id']}/reset-password")
+            st.session_state["reset_temp_password"] = result.get("temporary_password", "")
+            st.rerun()
+    else:
+        temp_pw = st.session_state["reset_temp_password"]
+        st.success(f"Password reset for **{user.get('email')}**.")
+        st.warning("⚠️ This password is shown **once only**. Copy it now.")
+        st.code(temp_pw, language=None)
+        if st.button("Done", type="primary", use_container_width=True):
+            del st.session_state["reset_temp_password"]
+            st.session_state.pop("_reset_password_target", None)
+            st.rerun()
+
+
+@st.dialog("Confirm Delete User")
+def _confirm_delete_user_dialog():
+    user = st.session_state.get("_delete_user_target", {})
+    st.markdown(f"Delete **{user.get('email')}**?")
+    st.caption("This action cannot be undone.")
+    c1, c2 = st.columns(2)
+    if c1.button("Cancel", use_container_width=True):
+        st.session_state.pop("_delete_user_target", None)
+        st.rerun()
+    if c2.button("Delete", type="primary", use_container_width=True):
+        with st.spinner("Deleting…"):
+            api.delete(f"/admin/users/{user['id']}")
+        st.session_state.pop("_delete_user_target", None)
+        st.toast(f"User '{user.get('email')}' deleted.", icon="✓")
+        st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Page
+# ---------------------------------------------------------------------------
+
+hdr, btn_col = st.columns([5, 1])
+hdr.markdown("""
+<div class="cl-page-header">
+    <h1>Users</h1>
+    <p>Manage access and roles</p>
+</div>
+""", unsafe_allow_html=True)
+with btn_col:
+    st.write("")
+    st.write("")
+    if st.button("＋ Add User", type="primary", use_container_width=True):
+        _add_user_dialog()
+
+with st.spinner(""):
+    users = api.get("/admin/users")
+
+if not users:
+    st.info("No users found.")
+else:
+    current_user_id = st.session_state.get("user_id")
+
+    for user in users:
+        is_self = user["id"] == current_user_id
+        with st.container(border=True):
+            info_col, actions_col = st.columns([4, 3])
+
+            with info_col:
+                you_tag = " <span style='color:#4B5563;font-size:12px'>(you)</span>" if is_self else ""
+                role_color = "#818CF8" if user["role"] == "admin" else "#4B5563"
+                mcp_badge = " <span style='background:#3B1F1F;color:#F87171;border-radius:4px;padding:1px 6px;font-size:10px;font-weight:600'>MUST CHANGE PW</span>" if user.get("must_change_password") else ""
+                st.markdown(
+                    f"**{user['email']}**{you_tag}"
+                    f"&nbsp;&nbsp;<span style='background:rgba(99,102,241,.15);color:{role_color};"
+                    f"border-radius:4px;padding:1px 8px;font-size:11px;font-weight:600'>"
+                    f"{user['role'].upper()}</span>{mcp_badge}",
+                    unsafe_allow_html=True,
+                )
+                joined = (user.get("created_at") or "")[:10]
+                last   = user.get("last_login") or "Never"
+                st.caption(f"Joined: {joined} · Last login: {last}")
+
+            with actions_col:
+                a1, a2, a3 = st.columns(3)
+
+                promote_label = "Revoke Admin" if user["role"] == "admin" else "Make Admin"
+                if a1.button(promote_label, key=f"promote_{user['id']}", disabled=is_self, use_container_width=True):
+                    new_role = "user" if user["role"] == "admin" else "admin"
+                    with st.spinner(""):
+                        api.patch(f"/admin/users/{user['id']}", json={"role": new_role})
+                    st.toast("Role updated.", icon="✓")
+                    st.rerun()
+
+                if a2.button("Reset PW", key=f"reset_{user['id']}", use_container_width=True):
+                    st.session_state["_reset_password_target"] = user
+                    _reset_password_dialog()
+
+                if a3.button("Delete", key=f"delete_user_{user['id']}", disabled=is_self, use_container_width=True):
+                    st.session_state["_delete_user_target"] = user
+                    _confirm_delete_user_dialog()

--- a/streamlit_app/requirements.txt
+++ b/streamlit_app/requirements.txt
@@ -1,0 +1,3 @@
+streamlit>=1.35.0
+requests>=2.32.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

- Complete Streamlit presentation layer for issue #11 (Admin Panel) + #12 (Demo Interface)
- Thin HTTP client — Streamlit talks to FastAPI over REST/SSE, no direct DB access (ADR-003)
- Ships with `MOCK_MODE = True` so the UI runs standalone before the backend is ready

## What's included

**Auth**
- Login + forced change-password flow on first login
- Role-based navigation: `user` sees only Ask page, `admin` sees full panel

**Admin Panel (#11)**
- Dashboard: KPI cards, recent jobs table, system health card
- Repositories: add/re-index/delete with confirmation dialogs, detail view
- Domains: list with repo filter, edit summary, human-verified toggle, LLM re-generate
- Users: add user with one-time temp password, reset password, promote/revoke admin, delete

**Ask Interface (#12)**
- SSE streaming chat with tool-call transparency (running → done events)
- Persona toggle: Developer / Product Manager / Legal
- Domain browser in sidebar auto-sends domain prompt
- Empty state with example prompt cards

## How to run

```bash
cd streamlit_app
pip install -r requirements.txt
streamlit run Home.py
Login: user / user (chat only) or admin / admin (full panel)

Notes
Flip MOCK_MODE = False in lib/api_client.py to wire up the real FastAPI backend
Page named "Ask CodeLens" instead of "Demo" per UX feedback — routing and guards unchanged

