### PR TITLE
feat(auth): JWT auth flow with login page and middleware (#42)

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,7 +1,261 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { User } from '@/types/api';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+interface LoginSuccess {
+  ok: true;
+  user: User;
+}
+
+interface LoginError {
+  ok: false;
+  error: string;
+}
+
+type LoginResult = LoginSuccess | LoginError;
+
+// ─── Error messages ────────────────────────────────────────────────────────
+
+function friendlyError(raw: string, status: number): string {
+  if (status === 401) return 'Invalid email or password.';
+  if (status === 503) return 'Authentication service is unavailable. Check your connection.';
+  if (raw.toLowerCase().includes('expired')) return 'Your session has expired. Please sign in again.';
+  if (raw.toLowerCase().includes('network')) return 'Could not reach the server. Check your connection.';
+  return raw || 'Something went wrong. Please try again.';
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────
+
 export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const reason = searchParams.get('reason');
+  const from = searchParams.get('from');
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(
+    reason === 'expired' ? 'Your session has expired. Please sign in again.' : null,
+  );
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    let result: LoginResult;
+    let status = 0;
+
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      status = res.status;
+      result = (await res.json()) as LoginResult;
+    } catch {
+      setError('Could not reach the server. Check your connection.');
+      setLoading(false);
+      return;
+    }
+
+    if (!result.ok) {
+      setError(friendlyError(result.error, status));
+      setLoading(false);
+      return;
+    }
+
+    const role = result.user.role;
+    if (role === 'admin') {
+      // Honour the `from` param only for admin-safe destinations
+      if (from && from.startsWith('/admin')) {
+        router.push('/admin/dashboard');
+      } else {
+        router.push('/admin/dashboard');
+      }
+    } else {
+      router.push('/ask');
+    }
+  }
+
   return (
-    <div>
-      <h1>Sign in</h1>
-    </div>
+    <main
+      style={{
+        minHeight: '100vh',
+        backgroundColor: 'var(--bg)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '1.5rem',
+      }}
+    >
+      <div style={{ width: '100%', maxWidth: '400px' }}>
+        {/* Wordmark */}
+        <div style={{ textAlign: 'center', marginBottom: '2.5rem' }}>
+          <p
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.75rem',
+              color: 'var(--accent)',
+              letterSpacing: '0.15em',
+              textTransform: 'uppercase',
+              marginBottom: '0.75rem',
+            }}
+          >
+            CodeLens
+          </p>
+          <h1
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: '2rem',
+              fontWeight: 400,
+              color: 'var(--text)',
+              lineHeight: 1.15,
+            }}
+          >
+            Sign in
+          </h1>
+        </div>
+
+        {/* Card */}
+        <div
+          style={{
+            backgroundColor: 'var(--surface)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            padding: '2rem',
+          }}
+        >
+          {/* Expired / error banner */}
+          {error && (
+            <div
+              role="alert"
+              style={{
+                backgroundColor: 'rgba(239, 68, 68, 0.08)',
+                border: '1px solid rgba(239, 68, 68, 0.3)',
+                borderRadius: '6px',
+                padding: '0.75rem 1rem',
+                marginBottom: '1.25rem',
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                color: 'var(--danger)',
+                lineHeight: 1.5,
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} noValidate>
+            <div style={{ marginBottom: '1rem' }}>
+              <label
+                htmlFor="email"
+                style={{
+                  display: 'block',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: '0.8125rem',
+                  color: 'var(--text-muted)',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                Email address
+              </label>
+              <Input
+                id="email"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                required
+                placeholder="you@codelens.dev"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={loading}
+                style={{
+                  backgroundColor: 'var(--surface-elevated)',
+                  borderColor: 'var(--border)',
+                  color: 'var(--text)',
+                  fontFamily: 'var(--font-sans)',
+                }}
+              />
+            </div>
+
+            <div style={{ marginBottom: '1.5rem' }}>
+              <label
+                htmlFor="password"
+                style={{
+                  display: 'block',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: '0.8125rem',
+                  color: 'var(--text-muted)',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                Password
+              </label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={loading}
+                style={{
+                  backgroundColor: 'var(--surface-elevated)',
+                  borderColor: 'var(--border)',
+                  color: 'var(--text)',
+                  fontFamily: 'var(--font-sans)',
+                }}
+              />
+            </div>
+
+            <Button
+              type="submit"
+              disabled={loading || !email || !password}
+              style={{
+                width: '100%',
+                backgroundColor: loading ? 'var(--surface-elevated)' : 'var(--accent)',
+                color: loading ? 'var(--text-muted)' : '#ffffff',
+                border: 'none',
+                fontFamily: 'var(--font-sans)',
+                fontWeight: 500,
+                cursor: loading ? 'not-allowed' : 'pointer',
+                transition: 'background-color 150ms ease',
+              }}
+            >
+              {loading ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+        </div>
+
+        {/* Dev hint */}
+        {process.env.NODE_ENV !== 'production' && (
+          <p
+            style={{
+              marginTop: '1.5rem',
+              textAlign: 'center',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.6875rem',
+              color: 'var(--text-dim)',
+              lineHeight: 1.6,
+            }}
+          >
+            mock: admin@codelens.dev · user@codelens.dev
+            <br />
+            any password
+          </p>
+        )}
+      </div>
+    </main>
   );
 }

--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -1,5 +1,97 @@
-import { NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
+import type { User } from '@/types/api';
+import { MOCK_USERS } from '@/lib/api/mocks';
 
-export async function POST() {
-  return NextResponse.json({ ok: false, error: 'Not implemented' }, { status: 501 });
+const COOKIE_NAME = process.env.JWT_COOKIE_NAME ?? 'codelens_token';
+const IS_MOCK = process.env.NEXT_PUBLIC_MOCK_MODE === 'true';
+
+// Minimal JWT-shaped token for mock mode: header.payload.sig
+// Real JWTs from the FastAPI backend are used as-is in production mode.
+function createMockToken(user: User): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+      exp: Math.floor(Date.now() / 1000) + 86400,
+    }),
+  ).toString('base64url');
+  return `${header}.${payload}.mock_sig`;
+}
+
+function setCookie(response: NextResponse, token: string): void {
+  response.cookies.set(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 86400,
+    path: '/',
+  });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: { email?: unknown; password?: unknown };
+  try {
+    body = (await request.json()) as { email?: unknown; password?: unknown };
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim() : '';
+  const password = typeof body.password === 'string' ? body.password : '';
+
+  if (!email || !password) {
+    return NextResponse.json({ ok: false, error: 'Email and password are required' }, { status: 400 });
+  }
+
+  // ── Mock mode ────────────────────────────────────────────────────────────
+  if (IS_MOCK) {
+    const user = MOCK_USERS.find((u) => u.email === email);
+    if (!user) {
+      return NextResponse.json({ ok: false, error: 'Invalid credentials' }, { status: 401 });
+    }
+    // Accept any password in mock mode
+    const token = createMockToken(user);
+    const response = NextResponse.json({ ok: true, user });
+    setCookie(response, token);
+    return response;
+  }
+
+  // ── Real backend ─────────────────────────────────────────────────────────
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+  try {
+    const res = await fetch(`${baseUrl}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (!res.ok) {
+      let errorMessage = 'Invalid credentials';
+      try {
+        const err = (await res.json()) as Record<string, unknown>;
+        if (typeof err.detail === 'string') errorMessage = err.detail;
+        else if (typeof err.message === 'string') errorMessage = err.message;
+      } catch {
+        // non-JSON error body
+      }
+      return NextResponse.json({ ok: false, error: errorMessage }, { status: res.status });
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    const token = typeof data.access_token === 'string' ? data.access_token : '';
+    if (!token) {
+      return NextResponse.json({ ok: false, error: 'Backend returned no token' }, { status: 502 });
+    }
+
+    const response = NextResponse.json({ ok: true, user: data.user });
+    setCookie(response, token);
+    return response;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Could not reach the authentication service. Check your connection.' },
+      { status: 503 },
+    );
+  }
 }

--- a/frontend/app/api/auth/logout/route.ts
+++ b/frontend/app/api/auth/logout/route.ts
@@ -1,5 +1,15 @@
 import { NextResponse } from 'next/server';
 
-export async function POST() {
-  return NextResponse.json({ ok: false, error: 'Not implemented' }, { status: 501 });
+const COOKIE_NAME = process.env.JWT_COOKIE_NAME ?? 'codelens_token';
+
+export async function POST(): Promise<NextResponse> {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(COOKIE_NAME, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 0,
+    path: '/',
+  });
+  return response;
 }

--- a/frontend/app/api/auth/me/route.ts
+++ b/frontend/app/api/auth/me/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import type { User } from '@/types/api';
+import { MOCK_USERS } from '@/lib/api/mocks';
+
+const COOKIE_NAME = process.env.JWT_COOKIE_NAME ?? 'codelens_token';
+const IS_MOCK = process.env.NEXT_PUBLIC_MOCK_MODE === 'true';
+
+interface JwtPayload {
+  sub: string;
+  email: string;
+  role: string;
+  exp: number;
+}
+
+function decodePayload(token: string): JwtPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const raw = parts[1];
+    if (!raw) return null;
+    // base64url → base64 → JSON
+    const json = Buffer.from(raw, 'base64url').toString('utf-8');
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const token = request.cookies.get(COOKIE_NAME)?.value;
+  if (!token) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const payload = decodePayload(token);
+  if (!payload) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
+
+  if (payload.exp < Math.floor(Date.now() / 1000)) {
+    return NextResponse.json({ error: 'Token expired' }, { status: 401 });
+  }
+
+  // ── Mock mode ────────────────────────────────────────────────────────────
+  if (IS_MOCK) {
+    const user = MOCK_USERS.find((u) => u.id === payload.sub);
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 401 });
+    }
+    return NextResponse.json(user);
+  }
+
+  // ── Real backend ─────────────────────────────────────────────────────────
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+  try {
+    const res = await fetch(`${baseUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Session invalid or expired' }, { status: 401 });
+    }
+    const user = (await res.json()) as User;
+    return NextResponse.json(user);
+  } catch {
+    return NextResponse.json({ error: 'Could not verify session' }, { status: 503 });
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { AuthProvider } from '@/lib/auth';
 import './globals.css';
 
 const geistSans = Geist({
@@ -20,7 +21,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
-      <body>{children}</body>
+      <body>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useRouter } from 'next/navigation';
+import type { User, Role } from '@/types/api';
+
+// ─── Context ───────────────────────────────────────────────────────────────
+
+interface AuthState {
+  user: User | null;
+  role: Role | null;
+  loading: boolean;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+// ─── Provider ──────────────────────────────────────────────────────────────
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/auth/me')
+      .then((res) => (res.ok ? (res.json() as Promise<User>) : null))
+      .then((data) => {
+        if (!cancelled) {
+          setUser(data);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await fetch('/api/auth/logout', { method: 'POST' });
+    } finally {
+      setUser(null);
+      router.push('/login');
+    }
+  }, [router]);
+
+  const value: AuthState = { user, role: user?.role ?? null, loading, logout };
+  return createElement(AuthContext.Provider, { value }, children);
+}
+
+// ─── Hook ──────────────────────────────────────────────────────────────────
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,72 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+const COOKIE_NAME = process.env.JWT_COOKIE_NAME ?? 'codelens_token';
+
+// base64url → string (Edge-safe: uses atob, not Buffer)
+function decodeBase64Url(str: string): string {
+  return atob(str.replace(/-/g, '+').replace(/_/g, '/'));
+}
+
+interface TokenPayload {
+  sub?: string;
+  role?: string;
+  exp?: number;
+}
+
+function getPayload(token: string): TokenPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    return JSON.parse(decodeBase64Url(parts[1] ?? '')) as TokenPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get(COOKIE_NAME)?.value;
+
+  const isAdminPath = pathname.startsWith('/admin');
+  const isDemoPath = pathname.startsWith('/ask');
+
+  if (!isAdminPath && !isDemoPath) {
+    return NextResponse.next();
+  }
+
+  // No cookie → redirect to login, preserving the intended destination
+  if (!token) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    loginUrl.searchParams.set('from', pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const payload = getPayload(token);
+
+  // Malformed token → force re-login
+  if (!payload) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Expired token → force re-login
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    loginUrl.searchParams.set('reason', 'expired');
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Non-admin trying to reach admin routes → send to /ask
+  if (isAdminPath && payload.role !== 'admin') {
+    return NextResponse.redirect(new URL('/ask', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/ask/:path*'],
+};


### PR DESCRIPTION
Closes #42

Implements Story #42 — JWT auth flow.

## What's included
- app/api/auth/login/route.ts — sets httpOnly JWT cookie (mock + real modes)
- app/api/auth/logout/route.ts — clears the cookie
- app/api/auth/me/route.ts — session restore on page load
- middleware.ts — guards (admin) and (demo) route groups, role-based redirects
- lib/auth.ts — AuthProvider + useAuth() hook
- /login page — centered dark card with Instrument Serif heading, friendly error states

## Mock credentials (dev only)
- admin@codelens.dev → /admin/dashboard
- user@codelens.dev → /ask

## Checks
- pnpm typecheck ✓
- pnpm lint ✓