### PR TITLE
feat(demo/admin): persona toggle, domain sidebar, users management (#50, #51, #46)

### DIFF
--- a/frontend/app/(admin)/admin/users/page.tsx
+++ b/frontend/app/(admin)/admin/users/page.tsx
@@ -1,16 +1,640 @@
-export default function UsersPage() {
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { listUsers, addUser, resetUserPassword, setUserRole, deleteUser } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/api/client';
+import { useAuth } from '@/lib/auth';
+import type { User, Role } from '@/types/api';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { MoreHorizontal, Plus, Copy, Check } from 'lucide-react';
+
+// ─── Temp password display ──────────────────────────────────────────────────
+
+function TempPasswordBlock({ password }: { password: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(password);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
   return (
-    <div
-      style={{
-        padding: '2rem',
-        maxWidth: '1400px',
-        margin: '0 auto',
-        fontFamily: 'var(--font-sans)',
-        color: 'var(--text-dim)',
-        fontSize: '0.875rem',
-      }}
-    >
-      Users management — Story #46
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          backgroundColor: 'var(--surface-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          padding: '0.5rem 0.75rem',
+        }}
+      >
+        <code
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.875rem',
+            color: 'var(--text)',
+            flex: 1,
+            letterSpacing: '0.05em',
+          }}
+        >
+          {password}
+        </code>
+        <button
+          onClick={() => void handleCopy()}
+          title="Copy password"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '24px',
+            height: '24px',
+            borderRadius: '4px',
+            border: 'none',
+            backgroundColor: 'transparent',
+            color: copied ? 'var(--success)' : 'var(--text-dim)',
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </button>
+      </div>
+      <p
+        style={{
+          fontFamily: 'var(--font-sans)',
+          fontSize: '0.75rem',
+          color: 'var(--warning)',
+          margin: 0,
+          lineHeight: 1.5,
+        }}
+      >
+        ⚠ This password will not be shown again. Copy it now.
+      </p>
+    </div>
+  );
+}
+
+// ─── Add user dialog ────────────────────────────────────────────────────────
+
+interface AddUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function AddUserDialog({ open, onOpenChange }: AddUserDialogProps) {
+  const queryClient = useQueryClient();
+  const [email, setEmail] = useState('');
+  const [tempPassword, setTempPassword] = useState<string | null>(null);
+
+  function handleClose(v: boolean) {
+    if (!v) {
+      setEmail('');
+      setTempPassword(null);
+    }
+    onOpenChange(v);
+  }
+
+  const mutation = useMutation({
+    mutationFn: (e: string) => addUser(e),
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      setTempPassword(data.temporaryPassword);
+      toast.success(`User ${data.user.email} added`);
+    },
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.message : 'Failed to add user');
+    },
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    mutation.mutate(email.trim());
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v: boolean) => handleClose(v)}>
+      <DialogContent style={{ maxWidth: '420px' }}>
+        <DialogHeader>
+          <DialogTitle>Add user</DialogTitle>
+        </DialogHeader>
+
+        {tempPassword ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <p
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                color: 'var(--text-muted)',
+                margin: 0,
+              }}
+            >
+              User created. Share this temporary password:
+            </p>
+            <TempPasswordBlock password={tempPassword} />
+            <DialogFooter>
+              <Button onClick={() => handleClose(false)}>Done</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.875rem' }}>
+            <div>
+              <label
+                style={{
+                  display: 'block',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: '0.8125rem',
+                  color: 'var(--text-muted)',
+                  marginBottom: '0.375rem',
+                }}
+              >
+                Email address
+              </label>
+              <Input
+                type="email"
+                placeholder="user@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <DialogFooter>
+              <Button type="submit" disabled={!email.trim() || mutation.isPending}>
+                {mutation.isPending ? 'Creating…' : 'Create user'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Reset password dialog ───────────────────────────────────────────────────
+
+interface ResetPasswordDialogProps {
+  user: User | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function ResetPasswordDialog({ user, open, onOpenChange }: ResetPasswordDialogProps) {
+  const [tempPassword, setTempPassword] = useState<string | null>(null);
+
+  function handleClose(v: boolean) {
+    if (!v) setTempPassword(null);
+    onOpenChange(v);
+  }
+
+  const mutation = useMutation({
+    mutationFn: (id: string) => resetUserPassword(id),
+    onSuccess: (data) => {
+      setTempPassword(data.temporaryPassword);
+      toast.success('Password reset');
+    },
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.message : 'Failed to reset password');
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={(v: boolean) => handleClose(v)}>
+      <DialogContent style={{ maxWidth: '420px' }}>
+        <DialogHeader>
+          <DialogTitle>Reset password</DialogTitle>
+        </DialogHeader>
+
+        {tempPassword ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <p
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                color: 'var(--text-muted)',
+                margin: 0,
+              }}
+            >
+              New temporary password for{' '}
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8125rem', color: 'var(--text)' }}>
+                {user?.email}
+              </span>
+              :
+            </p>
+            <TempPasswordBlock password={tempPassword} />
+            <DialogFooter>
+              <Button onClick={() => handleClose(false)}>Done</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <p
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                color: 'var(--text-muted)',
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              Generate a new temporary password for{' '}
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8125rem', color: 'var(--text)' }}>
+                {user?.email}
+              </span>
+              ? The user will need to change it on next login.
+            </p>
+            <DialogFooter>
+              <Button
+                disabled={mutation.isPending}
+                onClick={() => { if (user) mutation.mutate(user.id); }}
+              >
+                {mutation.isPending ? 'Generating…' : 'Reset password'}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Role confirm dialog ─────────────────────────────────────────────────────
+
+interface RoleDialogProps {
+  user: User | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (id: string, role: Role) => void;
+  isPending: boolean;
+}
+
+function RoleDialog({ user, open, onOpenChange, onConfirm, isPending }: RoleDialogProps) {
+  const newRole: Role = user?.role === 'admin' ? 'user' : 'admin';
+  return (
+    <Dialog open={open} onOpenChange={(v: boolean) => onOpenChange(v)}>
+      <DialogContent style={{ maxWidth: '400px' }}>
+        <DialogHeader>
+          <DialogTitle>Change role</DialogTitle>
+        </DialogHeader>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <p
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.875rem',
+              color: 'var(--text-muted)',
+              lineHeight: 1.6,
+              margin: 0,
+            }}
+          >
+            Change{' '}
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8125rem', color: 'var(--text)' }}>
+              {user?.email}
+            </span>{' '}
+            from <strong>{user?.role}</strong> to <strong>{newRole}</strong>?
+          </p>
+          <DialogFooter>
+            <Button
+              disabled={isPending}
+              onClick={() => { if (user) onConfirm(user.id, newRole); }}
+            >
+              {isPending ? 'Saving…' : `Set to ${newRole}`}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Delete confirm dialog ───────────────────────────────────────────────────
+
+interface DeleteDialogProps {
+  user: User | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (id: string) => void;
+  isPending: boolean;
+}
+
+function DeleteUserDialog({ user, open, onOpenChange, onConfirm, isPending }: DeleteDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v: boolean) => onOpenChange(v)}>
+      <DialogContent style={{ maxWidth: '400px' }}>
+        <DialogHeader>
+          <DialogTitle>Delete user</DialogTitle>
+        </DialogHeader>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <p
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.875rem',
+              color: 'var(--text-muted)',
+              lineHeight: 1.6,
+              margin: 0,
+            }}
+          >
+            Permanently delete{' '}
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8125rem', color: 'var(--text)' }}>
+              {user?.email}
+            </span>
+            ? This cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button
+              variant="destructive"
+              disabled={isPending}
+              onClick={() => { if (user) onConfirm(user.id); }}
+            >
+              {isPending ? 'Deleting…' : 'Delete user'}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string | null) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-GB', { dateStyle: 'medium' });
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function UsersPage() {
+  const queryClient = useQueryClient();
+  const { user: currentUser } = useAuth();
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [resetTarget, setResetTarget] = useState<User | null>(null);
+  const [roleTarget, setRoleTarget] = useState<User | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
+
+  const { data: users = [], isLoading } = useQuery({
+    queryKey: ['users'],
+    queryFn: listUsers,
+    refetchOnWindowFocus: true,
+  });
+
+  const roleMutation = useMutation({
+    mutationFn: ({ id, role }: { id: string; role: Role }) => setUserRole(id, role),
+    onSuccess: (updated) => {
+      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      setRoleTarget(null);
+      toast.success(`${updated.email} is now ${updated.role}`);
+    },
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.message : 'Failed to update role');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteUser(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['users'] });
+      setDeleteTarget(null);
+      toast.success('User deleted');
+    },
+    onError: (err) => {
+      toast.error(err instanceof ApiError ? err.message : 'Failed to delete user');
+    },
+  });
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '1400px', margin: '0 auto' }}>
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          marginBottom: '2rem',
+          animation: 'fade-up 300ms ease-out both',
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              fontFamily: "'Instrument Serif', Georgia, serif",
+              fontSize: '2rem',
+              fontWeight: 400,
+              color: 'var(--text)',
+              lineHeight: 1.1,
+              margin: 0,
+            }}
+          >
+            Users
+          </h1>
+          <p
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.875rem',
+              color: 'var(--text-dim)',
+              marginTop: '0.375rem',
+            }}
+          >
+            {users.length} user{users.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <Button
+          onClick={() => setAddOpen(true)}
+          style={{ display: 'flex', alignItems: 'center', gap: '0.375rem' }}
+        >
+          <Plus size={14} />
+          Add user
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div
+        style={{
+          backgroundColor: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          overflow: 'hidden',
+          animation: 'fade-up 300ms ease-out 50ms both',
+        }}
+      >
+        {isLoading ? (
+          <div style={{ padding: '1rem 1.25rem', display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead style={{ color: 'var(--text-dim)', fontSize: '0.75rem' }}>Email</TableHead>
+                <TableHead style={{ color: 'var(--text-dim)', fontSize: '0.75rem' }}>Role</TableHead>
+                <TableHead style={{ color: 'var(--text-dim)', fontSize: '0.75rem' }}>Created</TableHead>
+                <TableHead style={{ color: 'var(--text-dim)', fontSize: '0.75rem' }}>Last login</TableHead>
+                <TableHead style={{ color: 'var(--text-dim)', fontSize: '0.75rem', width: '48px' }} />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((u) => {
+                const isSelf = u.id === currentUser?.id;
+                return (
+                  <TableRow key={u.id}>
+                    <TableCell>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        <span
+                          style={{
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: '0.8125rem',
+                            color: 'var(--text)',
+                          }}
+                        >
+                          {u.email}
+                        </span>
+                        {isSelf && (
+                          <span
+                            style={{
+                              fontFamily: 'var(--font-mono)',
+                              fontSize: '0.6875rem',
+                              color: 'var(--text-dim)',
+                              border: '1px solid var(--border)',
+                              borderRadius: '4px',
+                              padding: '0 0.375rem',
+                            }}
+                          >
+                            you
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={u.role === 'admin' ? 'default' : 'secondary'}
+                        style={
+                          u.role === 'admin'
+                            ? { backgroundColor: 'var(--accent-glow)', color: 'var(--accent)', border: '1px solid rgba(139,92,246,0.3)' }
+                            : {}
+                        }
+                      >
+                        {u.role}
+                      </Badge>
+                    </TableCell>
+                    <TableCell
+                      style={{
+                        fontFamily: 'var(--font-sans)',
+                        fontSize: '0.8125rem',
+                        color: 'var(--text-dim)',
+                      }}
+                    >
+                      {formatDate(u.createdAt)}
+                    </TableCell>
+                    <TableCell
+                      style={{
+                        fontFamily: 'var(--font-sans)',
+                        fontSize: '0.8125rem',
+                        color: 'var(--text-dim)',
+                      }}
+                    >
+                      {formatDate(u.lastLogin)}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            width: '28px',
+                            height: '28px',
+                            borderRadius: '4px',
+                            border: 'none',
+                            backgroundColor: 'transparent',
+                            color: 'var(--text-dim)',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          <MoreHorizontal size={15} />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onSelect={() => setResetTarget(u)}>
+                            Reset password
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            disabled={isSelf}
+                            title={isSelf ? 'You cannot change your own role' : undefined}
+                            onSelect={() => !isSelf && setRoleTarget(u)}
+                          >
+                            {u.role === 'admin' ? 'Demote to user' : 'Promote to admin'}
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            variant="destructive"
+                            disabled={isSelf}
+                            title={isSelf ? 'You cannot delete your own account' : undefined}
+                            onSelect={() => !isSelf && setDeleteTarget(u)}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+
+      {/* Dialogs */}
+      <AddUserDialog open={addOpen} onOpenChange={setAddOpen} />
+      <ResetPasswordDialog
+        user={resetTarget}
+        open={resetTarget !== null}
+        onOpenChange={(v) => { if (!v) setResetTarget(null); }}
+      />
+      <RoleDialog
+        user={roleTarget}
+        open={roleTarget !== null}
+        onOpenChange={(v) => { if (!v) setRoleTarget(null); }}
+        onConfirm={(id, role) => roleMutation.mutate({ id, role })}
+        isPending={roleMutation.isPending}
+      />
+      <DeleteUserDialog
+        user={deleteTarget}
+        open={deleteTarget !== null}
+        onOpenChange={(v) => { if (!v) setDeleteTarget(null); }}
+        onConfirm={(id) => deleteMutation.mutate(id)}
+        isPending={deleteMutation.isPending}
+      />
     </div>
   );
 }

--- a/frontend/app/(demo)/ask/page.tsx
+++ b/frontend/app/(demo)/ask/page.tsx
@@ -3,20 +3,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
+import { PersonaToggle } from '@/components/chat/PersonaToggle';
+import { DomainSidebar } from '@/components/chat/DomainSidebar';
 import type { Persona } from '@/types/api';
 
-// ─── Storage keys (imported by Story #48 chat implementation) ──────────────
+// ─── Storage keys (imported by Story #49 chat implementation) ──────────────
 export const QUESTION_KEY = 'codelens_pending_question';
 export const PERSONA_KEY = 'codelens_persona';
 
 const PERSONAS: Persona[] = ['developer', 'product', 'legal'];
-const PERSONA_LABELS: Record<Persona, string> = {
-  developer: 'Developer',
-  product: 'Product',
-  legal: 'Legal',
-};
 
-// ─── 401 re-auth helper (called by chat SSE handler in Story #48) ──────────
+// ─── 401 re-auth helper (called by chat SSE handler in Story #49) ──────────
 export function triggerReAuth(pendingQuestion?: string): void {
   if (typeof window === 'undefined') return;
   if (pendingQuestion?.trim()) {
@@ -32,7 +29,7 @@ export default function AskPage() {
   const router = useRouter();
 
   const [persona, setPersona] = useState<Persona>('developer');
-  // Pending question restored after a re-auth redirect
+  const [inputValue, setInputValue] = useState('');
   const [restoredQuestion, setRestoredQuestion] = useState<string | null>(null);
   const restored = useRef(false);
 
@@ -49,6 +46,7 @@ export default function AskPage() {
     const savedQ = sessionStorage.getItem(QUESTION_KEY);
     if (savedQ) {
       setRestoredQuestion(savedQ);
+      setInputValue(savedQ);
       sessionStorage.removeItem(QUESTION_KEY);
     }
   }, []);
@@ -58,151 +56,234 @@ export default function AskPage() {
     sessionStorage.setItem(PERSONA_KEY, persona);
   }, [persona]);
 
-  function cyclePersona() {
-    setPersona((p) => {
-      const next = PERSONAS[(PERSONAS.indexOf(p) + 1) % PERSONAS.length];
-      return next ?? p;
-    });
-  }
-
-  // Redirect unauthenticated users (extra client-side guard; middleware is primary)
+  // Redirect unauthenticated users
   useEffect(() => {
     if (!loading && !user) {
       router.push('/login');
     }
   }, [loading, user, router]);
 
+  function handlePersonaChange(p: Persona) {
+    setPersona(p);
+    // Switching mid-conversation only affects the next response — no message rewrite needed
+  }
+
+  function handleInsertPrompt(prompt: string) {
+    setInputValue(prompt);
+  }
+
   return (
     <div
       style={{
-        minHeight: '100vh',
+        height: '100vh',
         backgroundColor: 'var(--bg)',
         display: 'flex',
-        flexDirection: 'column',
+        overflow: 'hidden',
       }}
     >
-      {/* ── Header ─────────────────────────────────────────────────────── */}
-      <header
-        style={{
-          height: '52px',
-          borderBottom: '1px solid var(--border)',
-          backgroundColor: 'var(--surface)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '0 1.5rem',
-          flexShrink: 0,
-        }}
-      >
-        {/* Wordmark */}
-        <span
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: '0.8125rem',
-            color: 'var(--accent)',
-            letterSpacing: '0.08em',
-          }}
-        >
-          CodeLens
-        </span>
+      {/* Domain browser sidebar (Story #51) */}
+      <DomainSidebar onInsertPrompt={handleInsertPrompt} />
 
-        {/* Persona badge — full segmented control added in Story #50 */}
-        <button
-          onClick={cyclePersona}
-          title="Click to switch persona (full toggle in Story #50)"
-          style={{
-            fontFamily: 'var(--font-sans)',
-            fontSize: '0.75rem',
-            color: 'var(--accent)',
-            backgroundColor: 'var(--accent-glow)',
-            border: '1px solid var(--accent)',
-            borderRadius: '999px',
-            padding: '0.25rem 0.75rem',
-            cursor: 'pointer',
-            letterSpacing: '0.03em',
-          }}
-        >
-          {PERSONA_LABELS[persona]}
-        </button>
-
-        {/* User chip + logout */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-          {!loading && user && (
-            <span
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: '0.75rem',
-                color: 'var(--text-muted)',
-                backgroundColor: 'var(--surface-elevated)',
-                border: '1px solid var(--border)',
-                borderRadius: '6px',
-                padding: '0.25rem 0.625rem',
-              }}
-            >
-              {user.email}
-            </span>
-          )}
-          <button
-            onClick={() => void logout()}
-            style={{
-              fontFamily: 'var(--font-sans)',
-              fontSize: '0.75rem',
-              color: 'var(--text-dim)',
-              backgroundColor: 'transparent',
-              border: '1px solid var(--border)',
-              borderRadius: '6px',
-              padding: '0.25rem 0.625rem',
-              cursor: 'pointer',
-            }}
-          >
-            Log out
-          </button>
-        </div>
-      </header>
-
-      {/* ── Chat area (Story #48) ───────────────────────────────────────── */}
-      <main
+      {/* Chat column */}
+      <div
         style={{
           flex: 1,
           display: 'flex',
           flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: '2rem',
-          gap: '1rem',
+          minWidth: 0,
         }}
       >
-        {restoredQuestion && (
-          <div
-            style={{
-              maxWidth: '560px',
-              width: '100%',
-              backgroundColor: 'var(--surface)',
-              border: '1px solid var(--border)',
-              borderRadius: '8px',
-              padding: '1rem 1.25rem',
-              fontFamily: 'var(--font-sans)',
-              fontSize: '0.875rem',
-              color: 'var(--text-muted)',
-              lineHeight: 1.6,
-            }}
-          >
-            <span style={{ color: 'var(--text-dim)', marginRight: '0.5rem' }}>↩</span>
-            Restored:{' '}
-            <span style={{ color: 'var(--text)' }}>&ldquo;{restoredQuestion}&rdquo;</span>
-          </div>
-        )}
-
-        <p
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <header
           style={{
-            fontFamily: 'var(--font-sans)',
-            fontSize: '0.875rem',
-            color: 'var(--text-dim)',
+            height: '52px',
+            borderBottom: '1px solid var(--border)',
+            backgroundColor: 'var(--surface)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '0 1.5rem',
+            flexShrink: 0,
+            gap: '1rem',
           }}
         >
-          Chat UI — Story #48
-        </p>
-      </main>
+          {/* Wordmark */}
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.8125rem',
+              color: 'var(--accent)',
+              letterSpacing: '0.08em',
+              flexShrink: 0,
+            }}
+          >
+            CodeLens
+          </span>
+
+          {/* Persona toggle (Story #50) */}
+          <PersonaToggle value={persona} onChange={handlePersonaChange} />
+
+          {/* User chip + logout */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
+            {!loading && user && (
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.75rem',
+                  color: 'var(--text-muted)',
+                  backgroundColor: 'var(--surface-elevated)',
+                  border: '1px solid var(--border)',
+                  borderRadius: '6px',
+                  padding: '0.25rem 0.625rem',
+                }}
+              >
+                {user.email}
+              </span>
+            )}
+            <button
+              onClick={() => void logout()}
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.75rem',
+                color: 'var(--text-dim)',
+                backgroundColor: 'transparent',
+                border: '1px solid var(--border)',
+                borderRadius: '6px',
+                padding: '0.25rem 0.625rem',
+                cursor: 'pointer',
+              }}
+            >
+              Log out
+            </button>
+          </div>
+        </header>
+
+        {/* ── Messages area ───────────────────────────────────────────────── */}
+        <main
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '2rem',
+            gap: '1rem',
+          }}
+        >
+          {restoredQuestion && (
+            <div
+              style={{
+                maxWidth: '560px',
+                width: '100%',
+                backgroundColor: 'var(--surface)',
+                border: '1px solid var(--border)',
+                borderRadius: '8px',
+                padding: '1rem 1.25rem',
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                color: 'var(--text-muted)',
+                lineHeight: 1.6,
+              }}
+            >
+              <span style={{ color: 'var(--text-dim)', marginRight: '0.5rem' }}>↩</span>
+              Restored:{' '}
+              <span style={{ color: 'var(--text)' }}>&ldquo;{restoredQuestion}&rdquo;</span>
+            </div>
+          )}
+
+          {/* Empty state — replaced by ChatPage in Story #48 */}
+          <div
+            style={{
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+          >
+            <p
+              style={{
+                fontFamily: "'Instrument Serif', Georgia, serif",
+                fontSize: '1.75rem',
+                fontWeight: 400,
+                color: 'var(--text)',
+                margin: 0,
+              }}
+            >
+              Ask CodeLens
+            </p>
+            <p
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                color: 'var(--text-dim)',
+                margin: 0,
+              }}
+            >
+              Chat implementation — Story #48
+            </p>
+          </div>
+        </main>
+
+        {/* ── Chat input stub (replaced by ChatInput in Story #48) ─────── */}
+        <div
+          style={{
+            borderTop: '1px solid var(--border)',
+            backgroundColor: 'var(--surface)',
+            padding: '0.875rem 1.5rem',
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              maxWidth: '720px',
+              margin: '0 auto',
+              display: 'flex',
+              gap: '0.75rem',
+              alignItems: 'flex-end',
+            }}
+          >
+            <textarea
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="Ask about your codebase…"
+              rows={2}
+              style={{
+                flex: 1,
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.9375rem',
+                color: 'var(--text)',
+                backgroundColor: 'var(--surface-elevated)',
+                border: '1px solid var(--border)',
+                borderRadius: '8px',
+                padding: '0.625rem 0.875rem',
+                resize: 'none',
+                outline: 'none',
+                lineHeight: 1.5,
+              }}
+            />
+            <button
+              disabled
+              title="Chat implementation coming in Story #48"
+              style={{
+                padding: '0.625rem 1.25rem',
+                borderRadius: '8px',
+                border: 'none',
+                backgroundColor: 'var(--accent)',
+                color: '#fff',
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.875rem',
+                cursor: 'not-allowed',
+                opacity: 0.5,
+                flexShrink: 0,
+              }}
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/components/chat/DomainSidebar.tsx
+++ b/frontend/components/chat/DomainSidebar.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listDomains } from '@/lib/api/endpoints';
+import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
+
+interface DomainSidebarProps {
+  onInsertPrompt: (prompt: string) => void;
+}
+
+export function DomainSidebar({ onInsertPrompt }: DomainSidebarProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [search, setSearch] = useState('');
+  const [activeDomainId, setActiveDomainId] = useState<string | null>(null);
+
+  const { data: domains = [] } = useQuery({
+    queryKey: ['domains', ''],
+    queryFn: () => listDomains(),
+  });
+
+  const filtered = domains.filter(
+    (d) =>
+      d.name.toLowerCase().includes(search.toLowerCase()) ||
+      d.summary.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  function handleDomainClick(id: string, name: string) {
+    setActiveDomainId(id);
+    onInsertPrompt(
+      `Tell me about the ${name} domain — what does it do, what are its key functions, and what are its dependencies?`,
+    );
+  }
+
+  if (collapsed) {
+    return (
+      <div
+        style={{
+          width: '36px',
+          minWidth: '36px',
+          backgroundColor: 'var(--surface)',
+          borderRight: '1px solid var(--border)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          paddingTop: '0.75rem',
+          flexShrink: 0,
+        }}
+      >
+        <button
+          onClick={() => setCollapsed(false)}
+          title="Expand domain browser"
+          style={{
+            width: '28px',
+            height: '28px',
+            borderRadius: '4px',
+            border: '1px solid var(--border)',
+            backgroundColor: 'transparent',
+            color: 'var(--text-dim)',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <ChevronRight size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: '260px',
+        minWidth: '260px',
+        backgroundColor: 'var(--surface)',
+        borderRight: '1px solid var(--border)',
+        display: 'flex',
+        flexDirection: 'column',
+        flexShrink: 0,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          height: '52px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 0.75rem',
+          borderBottom: '1px solid var(--border)',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.6875rem',
+            color: 'var(--text-dim)',
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Domains
+          {domains.length > 0 && (
+            <span style={{ marginLeft: '0.375rem', color: 'var(--text-dim)', opacity: 0.6 }}>
+              {domains.length}
+            </span>
+          )}
+        </span>
+        <button
+          onClick={() => setCollapsed(true)}
+          title="Collapse domain browser"
+          style={{
+            width: '24px',
+            height: '24px',
+            borderRadius: '4px',
+            border: 'none',
+            backgroundColor: 'transparent',
+            color: 'var(--text-dim)',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <ChevronLeft size={13} />
+        </button>
+      </div>
+
+      {/* Search */}
+      <div style={{ padding: '0.625rem 0.75rem', borderBottom: '1px solid var(--border)', flexShrink: 0 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            backgroundColor: 'var(--surface-elevated)',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            padding: '0.375rem 0.625rem',
+          }}
+        >
+          <Search size={12} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />
+          <input
+            type="text"
+            placeholder="Filter domains…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.8125rem',
+              color: 'var(--text)',
+              backgroundColor: 'transparent',
+              border: 'none',
+              outline: 'none',
+              width: '100%',
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Domain list */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {domains.length === 0 ? (
+          <div
+            style={{
+              padding: '2rem 1rem',
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.8125rem',
+              color: 'var(--text-dim)',
+              lineHeight: 1.6,
+              textAlign: 'center',
+            }}
+          >
+            No domains discovered yet.
+            <br />
+            Index a repository first.
+          </div>
+        ) : filtered.length === 0 ? (
+          <div
+            style={{
+              padding: '2rem 1rem',
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.8125rem',
+              color: 'var(--text-dim)',
+              textAlign: 'center',
+            }}
+          >
+            No domains match &ldquo;{search}&rdquo;
+          </div>
+        ) : (
+          filtered.map((domain) => {
+            const active = domain.id === activeDomainId;
+            return (
+              <button
+                key={domain.id}
+                onClick={() => handleDomainClick(domain.id, domain.name)}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '0.75rem 0.875rem',
+                  borderTop: 'none',
+                  borderRight: 'none',
+                  borderBottom: '1px solid var(--border)',
+                  borderLeft: active ? '2px solid var(--accent)' : '2px solid transparent',
+                  backgroundColor: active ? 'var(--accent-glow)' : 'transparent',
+                  cursor: 'pointer',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'baseline',
+                    justifyContent: 'space-between',
+                    gap: '0.5rem',
+                    marginBottom: '0.25rem',
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: '0.8125rem',
+                      fontWeight: 500,
+                      color: active ? 'var(--text)' : 'var(--text-muted)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {domain.name}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: '0.6875rem',
+                      color: 'var(--text-dim)',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {domain.memberCount}
+                  </span>
+                </div>
+                <p
+                  style={{
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: '0.75rem',
+                    color: 'var(--text-dim)',
+                    margin: 0,
+                    overflow: 'hidden',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {domain.summary}
+                </p>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/chat/PersonaToggle.tsx
+++ b/frontend/components/chat/PersonaToggle.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import type { Persona } from '@/types/api';
+
+interface PersonaOption {
+  value: Persona;
+  label: string;
+  desc: string;
+}
+
+const OPTIONS: PersonaOption[] = [
+  {
+    value: 'developer',
+    label: 'Developer',
+    desc: 'Technical implementation details, code structure, and system design',
+  },
+  {
+    value: 'product',
+    label: 'Product',
+    desc: 'Feature behaviour, user flows, and business logic',
+  },
+  {
+    value: 'legal',
+    label: 'Legal',
+    desc: 'Compliance concerns, data handling, and regulatory considerations',
+  },
+];
+
+interface PersonaToggleProps {
+  value: Persona;
+  onChange: (p: Persona) => void;
+}
+
+export function PersonaToggle({ value, onChange }: PersonaToggleProps) {
+  const [hovered, setHovered] = useState<Persona | null>(null);
+  const hoveredOption = OPTIONS.find((o) => o.value === hovered);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.25rem' }}>
+      {/* Segmented control */}
+      <div
+        style={{
+          display: 'flex',
+          backgroundColor: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '3px',
+          gap: '2px',
+        }}
+      >
+        {OPTIONS.map((opt) => {
+          const active = opt.value === value;
+          return (
+            <button
+              key={opt.value}
+              onClick={() => onChange(opt.value)}
+              onMouseEnter={() => setHovered(opt.value)}
+              onMouseLeave={() => setHovered(null)}
+              style={{
+                padding: '0.3125rem 0.875rem',
+                borderRadius: '5px',
+                border: active ? '1px solid var(--accent)' : '1px solid transparent',
+                backgroundColor: active ? 'var(--accent-glow)' : 'transparent',
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.8125rem',
+                color: active ? 'var(--accent)' : 'var(--text-dim)',
+                cursor: 'pointer',
+                transition: 'color 150ms, background-color 150ms, border-color 150ms',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Hover description */}
+      <div
+        style={{
+          height: '1rem',
+          fontFamily: 'var(--font-sans)',
+          fontSize: '0.6875rem',
+          color: 'var(--text-dim)',
+          transition: 'opacity 150ms',
+          opacity: hoveredOption ? 1 : 0,
+        }}
+      >
+        {hoveredOption?.desc ?? ''}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #50
Closes #51
Closes #46

## Story #50 — Persona toggle
- Segmented control on /ask replacing the cycling badge from #53
- Hover description, violet accent on active option
- Persists via shared PERSONA_KEY in sessionStorage
- Mid-conversation switches affect only the next response

## Story #51 — Domain browser sidebar
- Collapsible left sidebar (36px rail when collapsed)
- Client-side search filter (name + summary)
- Each item: domain name, member count, 2-line summary
- Click inserts templated prompt + highlights with violet left border
- Empty state + no-results state handled
- Chat input stub at bottom of /ask — #48 will replace it

## Story #46 — Users management (/admin/users)
- Table: email, role badge, created, last login, actions
- Add user dialog: email → copyable one-time temp password with warning
- Reset password reuses the temp-password flow
- Role toggle and delete gated behind confirm dialogs
- Current user row: delete/promote disabled with tooltip

## Checks
- pnpm typecheck ✓
- pnpm lint ✓
- All pages render in MOCK_MODE=true