### PR TITLE
feat(chat): SSE streaming with tool-call transparency (#49)

### DIFF
--- a/frontend/app/(demo)/ask/page.tsx
+++ b/frontend/app/(demo)/ask/page.tsx
@@ -7,14 +7,16 @@ import { PersonaToggle } from '@/components/chat/PersonaToggle';
 import { DomainSidebar } from '@/components/chat/DomainSidebar';
 import { EmptyState } from '@/components/chat/EmptyState';
 import { MessageBubble } from '@/components/chat/MessageBubble';
-import type { ChatMessage, Persona } from '@/types/api';
-import { ArrowUp } from 'lucide-react';
+import { createChatStream } from '@/lib/api/sse';
+import type { ChatEvent, ChatMessage, Persona, ToolCallRecord } from '@/types/api';
+import { ArrowUp, Square } from 'lucide-react';
 
 // ─── Storage keys ──────────────────────────────────────────────────────────
 export const QUESTION_KEY = 'codelens_pending_question';
 export const PERSONA_KEY = 'codelens_persona';
 
 const PERSONAS: Persona[] = ['developer', 'product', 'legal'];
+const MAX_HISTORY = 10;
 
 // ─── 401 re-auth helper ────────────────────────────────────────────────────
 export function triggerReAuth(pendingQuestion?: string): void {
@@ -25,17 +27,6 @@ export function triggerReAuth(pendingQuestion?: string): void {
   window.location.href = '/login?reason=expired';
 }
 
-// ─── Stub assistant response ───────────────────────────────────────────────
-const STUB_RESPONSE =
-  'This is a stub response — SSE streaming will be implemented in **Story #49**.\n\n' +
-  'Here is an example of markdown rendering:\n\n' +
-  '```typescript\n' +
-  'function applyDiscount(price: number, pct: number): number {\n' +
-  '  return price * (1 - pct / 100);\n' +
-  '}\n' +
-  '```\n\n' +
-  'Lists, **bold**, and `inline code` are also supported.';
-
 // ─── Page ──────────────────────────────────────────────────────────────────
 
 export default function AskPage() {
@@ -45,12 +36,19 @@ export default function AskPage() {
   const [persona, setPersona] = useState<Persona>('developer');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputValue, setInputValue] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamError, setStreamError] = useState<string | null>(null);
   const [restoredQuestion, setRestoredQuestion] = useState<string | null>(null);
 
   const bottomRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const restored = useRef(false);
+  // Tracks the active stream so we can cancel it
+  const activeStreamRef = useRef<{ cancel: () => void } | null>(null);
+  // Tracks the current pending question for 401 reauth
+  const pendingQuestionRef = useRef<string>('');
+  // Tracks retry state — one retry per submit
+  const hasRetriedRef = useRef(false);
 
   // Restore sessionStorage on first mount
   useEffect(() => {
@@ -94,16 +92,132 @@ export default function AskPage() {
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }
 
-  const submitMessage = useCallback(
-    async (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed || isSubmitting) return;
+  // Cancel the active stream
+  const cancelStream = useCallback(() => {
+    if (activeStreamRef.current) {
+      activeStreamRef.current.cancel();
+      activeStreamRef.current = null;
+    }
+    setIsStreaming(false);
+  }, []);
 
+  const runStream = useCallback(
+    (
+      text: string,
+      currentPersona: Persona,
+      history: ChatMessage[],
+      assistantMsgId: string,
+    ) => {
+      hasRetriedRef.current = false;
+      setStreamError(null);
+
+      const stream = createChatStream(text, currentPersona, history);
+      activeStreamRef.current = stream;
+
+      // Mutable accumulator for this stream run — kept in closure, flushed to React state via setMessages
+      const toolMap = new Map<string, ToolCallRecord>();
+      const toolOrder: string[] = [];
+      let textContent = '';
+
+      const flush = () => {
+        const toolCalls = toolOrder.map((id) => toolMap.get(id)!);
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantMsgId
+              ? { ...m, content: textContent, toolCalls }
+              : m,
+          ),
+        );
+      };
+
+      const handleEvent = (event: ChatEvent) => {
+        if (event.type === 'token') {
+          textContent += event.content;
+          flush();
+        } else if (event.type === 'tool_call_start') {
+          const tc: ToolCallRecord = {
+            id: event.id,
+            tool: event.tool,
+            args: event.args,
+            result: null,
+            durationMs: null,
+            status: 'running',
+            error: null,
+          };
+          toolMap.set(event.id, tc);
+          toolOrder.push(event.id);
+          flush();
+        } else if (event.type === 'tool_call_end') {
+          const existing = toolMap.get(event.id);
+          if (existing) {
+            toolMap.set(event.id, {
+              ...existing,
+              result: event.result,
+              durationMs: event.durationMs,
+              status: 'done',
+            });
+          } else {
+            const orphan: ToolCallRecord = {
+              id: event.id,
+              tool: 'unknown',
+              args: {},
+              result: event.result,
+              durationMs: event.durationMs,
+              status: 'error',
+              error: 'Unmatched tool_call_end',
+            };
+            toolMap.set(event.id, orphan);
+            toolOrder.push(event.id);
+          }
+          flush();
+        } else if (event.type === 'done') {
+          activeStreamRef.current = null;
+          setIsStreaming(false);
+        } else if (event.type === 'error') {
+          activeStreamRef.current = null;
+
+          // 401 → re-auth
+          if (event.message.includes('401') || event.message.includes('Unauthorized')) {
+            triggerReAuth(pendingQuestionRef.current);
+            return;
+          }
+
+          // First failure → retry once silently
+          if (!hasRetriedRef.current) {
+            hasRetriedRef.current = true;
+            toolMap.clear();
+            toolOrder.length = 0;
+            textContent = '';
+            flush();
+
+            const retryStream = createChatStream(text, currentPersona, history);
+            activeStreamRef.current = retryStream;
+            retryStream.onEvent(handleEvent);
+            return;
+          }
+
+          // Second failure → show error state
+          setStreamError(event.message);
+          setIsStreaming(false);
+        }
+      };
+
+      stream.onEvent(handleEvent);
+    },
+    [],
+  );
+
+  const submitMessage = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isStreaming) return;
+
+      pendingQuestionRef.current = trimmed;
       setInputValue('');
+      setStreamError(null);
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
       }
-      setIsSubmitting(true);
 
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
@@ -111,42 +225,47 @@ export default function AskPage() {
         content: trimmed,
         timestamp: new Date().toISOString(),
       };
-      setMessages((prev) => [...prev, userMsg]);
 
-      // Stub: 500ms delay then static assistant response
-      // Story #49 will replace this with SSE streaming
-      await new Promise<void>((resolve) => setTimeout(resolve, 500));
-
+      const assistantMsgId = crypto.randomUUID();
       const assistantMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: assistantMsgId,
         role: 'assistant',
-        content: STUB_RESPONSE,
+        content: '',
         timestamp: new Date().toISOString(),
+        toolCalls: [],
       };
-      setMessages((prev) => [...prev, assistantMsg]);
-      setIsSubmitting(false);
+
+      setMessages((prev) => {
+        const next = [...prev, userMsg, assistantMsg];
+        // Build history from all messages before the new ones (last MAX_HISTORY)
+        const history = prev.slice(-MAX_HISTORY);
+        // Defer stream start after state update
+        setTimeout(() => {
+          setIsStreaming(true);
+          runStream(trimmed, persona, history, assistantMsgId);
+        }, 0);
+        return next;
+      });
     },
-    [isSubmitting],
+    [isStreaming, persona, runStream],
   );
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      void submitMessage(inputValue);
+      submitMessage(inputValue);
     }
   }
 
-  // DomainSidebar click now auto-submits (no longer just fills input)
   const handleInsertPrompt = useCallback(
     (prompt: string) => {
-      void submitMessage(prompt);
+      submitMessage(prompt);
     },
     [submitMessage],
   );
 
   function handlePersonaChange(p: Persona) {
     setPersona(p);
-    // Switching mid-conversation only affects next response
   }
 
   return (
@@ -270,7 +389,7 @@ export default function AskPage() {
                 </span>
                 <button
                   onClick={() => {
-                    void submitMessage(restoredQuestion);
+                    submitMessage(restoredQuestion);
                     setRestoredQuestion(null);
                   }}
                   style={{
@@ -292,7 +411,7 @@ export default function AskPage() {
           )}
 
           {messages.length === 0 && !restoredQuestion ? (
-            <EmptyState onSubmit={(p) => void submitMessage(p)} />
+            <EmptyState onSubmit={submitMessage} />
           ) : (
             <div
               style={{
@@ -310,31 +429,102 @@ export default function AskPage() {
                 <MessageBubble key={msg.id} message={msg} />
               ))}
 
-              {/* Typing indicator */}
-              {isSubmitting && (
-                <div style={{ padding: '0 1rem' }}>
-                  <div
+              {/* Streaming indicator (only when no content yet) */}
+              {isStreaming &&
+                messages.length > 0 &&
+                messages[messages.length - 1].content === '' &&
+                (!messages[messages.length - 1].toolCalls ||
+                  messages[messages.length - 1].toolCalls!.length === 0) && (
+                  <div style={{ padding: '0 1rem' }}>
+                    <div
+                      style={{
+                        display: 'inline-flex',
+                        gap: '4px',
+                        padding: '0.5rem 0.75rem',
+                        borderLeft: '2px solid var(--accent)',
+                        paddingLeft: '0.875rem',
+                      }}
+                    >
+                      {[0, 1, 2].map((i) => (
+                        <span
+                          key={i}
+                          style={{
+                            width: '5px',
+                            height: '5px',
+                            borderRadius: '50%',
+                            backgroundColor: 'var(--text-dim)',
+                            animation: `pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+              {/* Stream error with retry */}
+              {streamError && (
+                <div
+                  style={{
+                    padding: '0 1rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.75rem',
+                  }}
+                >
+                  <span
                     style={{
-                      display: 'inline-flex',
-                      gap: '4px',
-                      padding: '0.5rem 0.75rem',
-                      borderLeft: '2px solid var(--accent)',
-                      paddingLeft: '0.875rem',
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: '0.875rem',
+                      color: 'var(--danger)',
                     }}
                   >
-                    {[0, 1, 2].map((i) => (
-                      <span
-                        key={i}
-                        style={{
-                          width: '5px',
-                          height: '5px',
-                          borderRadius: '50%',
-                          backgroundColor: 'var(--text-dim)',
-                          animation: `pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
-                        }}
-                      />
-                    ))}
-                  </div>
+                    Connection lost: {streamError}
+                  </span>
+                  <button
+                    onClick={() => {
+                      if (!pendingQuestionRef.current) return;
+                      // Remove the failed assistant message and retry
+                      setMessages((prev) => {
+                        const withoutLast =
+                          prev[prev.length - 1].role === 'assistant'
+                            ? prev.slice(0, -1)
+                            : prev;
+                        const history = withoutLast.slice(-MAX_HISTORY);
+                        const newAssistantId = crypto.randomUUID();
+                        const newAssistant: ChatMessage = {
+                          id: newAssistantId,
+                          role: 'assistant',
+                          content: '',
+                          timestamp: new Date().toISOString(),
+                          toolCalls: [],
+                        };
+                        setStreamError(null);
+                        setIsStreaming(true);
+                        setTimeout(() => {
+                          runStream(
+                            pendingQuestionRef.current,
+                            persona,
+                            history,
+                            newAssistantId,
+                          );
+                        }, 0);
+                        return [...withoutLast, newAssistant];
+                      });
+                    }}
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: '0.8125rem',
+                      color: 'var(--accent)',
+                      backgroundColor: 'transparent',
+                      border: '1px solid rgba(139,92,246,0.4)',
+                      borderRadius: '6px',
+                      padding: '0.25rem 0.625rem',
+                      cursor: 'pointer',
+                      flexShrink: 0,
+                    }}
+                  >
+                    Retry
+                  </button>
                 </div>
               )}
 
@@ -371,7 +561,7 @@ export default function AskPage() {
               onKeyDown={handleKeyDown}
               placeholder="Ask about your codebase… (Enter to send, Shift+Enter for newline)"
               rows={1}
-              disabled={isSubmitting}
+              disabled={isStreaming}
               style={{
                 flex: 1,
                 fontFamily: 'var(--font-sans)',
@@ -387,30 +577,55 @@ export default function AskPage() {
                 minHeight: '42px',
                 maxHeight: '200px',
                 overflowY: 'auto',
-                opacity: isSubmitting ? 0.6 : 1,
+                opacity: isStreaming ? 0.6 : 1,
               }}
             />
-            <button
-              onClick={() => void submitMessage(inputValue)}
-              disabled={!inputValue.trim() || isSubmitting}
-              style={{
-                width: '38px',
-                height: '38px',
-                borderRadius: '8px',
-                border: 'none',
-                backgroundColor:
-                  inputValue.trim() && !isSubmitting ? 'var(--accent)' : 'var(--surface-elevated)',
-                color: inputValue.trim() && !isSubmitting ? '#fff' : 'var(--text-dim)',
-                cursor: inputValue.trim() && !isSubmitting ? 'pointer' : 'not-allowed',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-                transition: 'background-color 150ms, color 150ms',
-              }}
-            >
-              <ArrowUp size={16} />
-            </button>
+            {/* Cancel button during streaming */}
+            {isStreaming ? (
+              <button
+                onClick={cancelStream}
+                style={{
+                  width: '38px',
+                  height: '38px',
+                  borderRadius: '8px',
+                  border: '1px solid var(--border-strong)',
+                  backgroundColor: 'var(--surface-elevated)',
+                  color: 'var(--text-muted)',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+                title="Cancel"
+              >
+                <Square size={14} />
+              </button>
+            ) : (
+              <button
+                onClick={() => submitMessage(inputValue)}
+                disabled={!inputValue.trim() || isStreaming}
+                style={{
+                  width: '38px',
+                  height: '38px',
+                  borderRadius: '8px',
+                  border: 'none',
+                  backgroundColor:
+                    inputValue.trim() && !isStreaming
+                      ? 'var(--accent)'
+                      : 'var(--surface-elevated)',
+                  color: inputValue.trim() && !isStreaming ? '#fff' : 'var(--text-dim)',
+                  cursor: inputValue.trim() && !isStreaming ? 'pointer' : 'not-allowed',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  transition: 'background-color 150ms, color 150ms',
+                }}
+              >
+                <ArrowUp size={16} />
+              </button>
+            )}
           </div>
           <p
             style={{
@@ -423,7 +638,8 @@ export default function AskPage() {
           >
             Persona:{' '}
             <span style={{ color: 'var(--text-muted)', textTransform: 'capitalize' }}>{persona}</span>
-            {' · '}Enter to send
+            {' · '}
+            {isStreaming ? 'Streaming…' : 'Enter to send'}
           </p>
         </div>
       </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -140,3 +140,8 @@
     transform: translateY(0);
   }
 }
+
+@keyframes tool-pulse {
+  0%, 100% { border-color: var(--accent); }
+  50% { border-color: rgba(139, 92, 246, 0.3); }
+}

--- a/frontend/components/chat/MessageBubble.tsx
+++ b/frontend/components/chat/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import type { ChatMessage } from '@/types/api';
 import { MarkdownContent } from './MarkdownContent';
+import { ToolCallCard } from './ToolCallCard';
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -36,6 +37,8 @@ export function MessageBubble({ message }: MessageBubbleProps) {
     );
   }
 
+  const hasToolCalls = message.toolCalls && message.toolCalls.length > 0;
+
   return (
     <div
       style={{
@@ -54,9 +57,22 @@ export function MessageBubble({ message }: MessageBubbleProps) {
           color: 'var(--text-muted)',
           lineHeight: 1.7,
           wordBreak: 'break-word',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.5rem',
         }}
       >
-        <MarkdownContent content={message.content} />
+        {/* Tool calls appear first, in invocation order */}
+        {hasToolCalls && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
+            {message.toolCalls!.map((tc) => (
+              <ToolCallCard key={tc.id} toolCall={tc} />
+            ))}
+          </div>
+        )}
+
+        {/* Streaming text content */}
+        {message.content && <MarkdownContent content={message.content} />}
       </div>
     </div>
   );

--- a/frontend/components/chat/ToolCallCard.tsx
+++ b/frontend/components/chat/ToolCallCard.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useState } from 'react';
+import type { ToolCallRecord } from '@/types/api';
+
+interface ToolCallCardProps {
+  toolCall: ToolCallRecord;
+}
+
+export function ToolCallCard({ toolCall }: ToolCallCardProps) {
+  const [argsExpanded, setArgsExpanded] = useState(false);
+  const [resultExpanded, setResultExpanded] = useState(false);
+
+  const isRunning = toolCall.status === 'running';
+  const isError = toolCall.status === 'error';
+
+  const borderColor = isError
+    ? 'var(--danger)'
+    : isRunning
+      ? 'var(--accent)'
+      : 'var(--border-strong)';
+
+  const argsJson = JSON.stringify(toolCall.args, null, 2);
+  const resultPreview =
+    toolCall.result && toolCall.result.length > 200
+      ? toolCall.result.slice(0, 200) + '…'
+      : toolCall.result;
+
+  return (
+    <div
+      style={{
+        borderRadius: '6px',
+        border: `1px solid ${borderColor}`,
+        backgroundColor: 'var(--surface)',
+        overflow: 'hidden',
+        fontSize: '0.8125rem',
+        fontFamily: 'var(--font-sans)',
+        animation: isRunning ? 'tool-pulse 2s ease-in-out infinite' : undefined,
+      }}
+    >
+      {/* Header row */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          padding: '0.5rem 0.75rem',
+          borderBottom: isRunning || toolCall.result || isError ? '1px solid var(--border)' : undefined,
+        }}
+      >
+        {/* Status indicator */}
+        {isRunning ? (
+          <span
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              backgroundColor: 'var(--accent)',
+              flexShrink: 0,
+              animation: 'pulse 1.2s ease-in-out infinite',
+            }}
+          />
+        ) : isError ? (
+          <span style={{ color: 'var(--danger)', flexShrink: 0, lineHeight: 1 }}>✕</span>
+        ) : (
+          <span style={{ color: 'var(--success)', flexShrink: 0, lineHeight: 1 }}>✓</span>
+        )}
+
+        {/* Tool name */}
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.75rem',
+            color: isRunning ? 'var(--accent)' : isError ? 'var(--danger)' : 'var(--text-muted)',
+            flex: 1,
+          }}
+        >
+          {toolCall.tool}
+        </span>
+
+        {/* Duration badge (done only) */}
+        {toolCall.status === 'done' && toolCall.durationMs !== null && (
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.6875rem',
+              color: 'var(--text-dim)',
+              backgroundColor: 'var(--surface-elevated)',
+              border: '1px solid var(--border)',
+              borderRadius: '4px',
+              padding: '0.1em 0.4em',
+            }}
+          >
+            {toolCall.durationMs}ms
+          </span>
+        )}
+
+        {/* Args expand toggle */}
+        <button
+          onClick={() => setArgsExpanded((v) => !v)}
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.6875rem',
+            color: 'var(--text-dim)',
+            backgroundColor: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '0.1em 0.25em',
+          }}
+          title={argsExpanded ? 'Collapse args' : 'Expand args'}
+        >
+          {argsExpanded ? '▲ args' : '▼ args'}
+        </button>
+      </div>
+
+      {/* Args block */}
+      {argsExpanded && (
+        <pre
+          style={{
+            margin: 0,
+            padding: '0.5rem 0.75rem',
+            backgroundColor: 'var(--surface-elevated)',
+            borderBottom:
+              (toolCall.result || isError) ? '1px solid var(--border)' : undefined,
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.75rem',
+            color: 'var(--text-muted)',
+            overflowX: 'auto',
+            lineHeight: 1.5,
+          }}
+        >
+          {argsJson}
+        </pre>
+      )}
+
+      {/* Result / error area */}
+      {isError && toolCall.error && (
+        <div
+          style={{
+            padding: '0.5rem 0.75rem',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.75rem',
+            color: 'var(--danger)',
+            lineHeight: 1.5,
+          }}
+        >
+          {toolCall.error}
+        </div>
+      )}
+
+      {toolCall.result && !isError && (
+        <div
+          style={{
+            padding: '0.5rem 0.75rem',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.75rem',
+            color: 'var(--text-dim)',
+            lineHeight: 1.5,
+          }}
+        >
+          {resultExpanded ? toolCall.result : resultPreview}
+          {toolCall.result.length > 200 && (
+            <button
+              onClick={() => setResultExpanded((v) => !v)}
+              style={{
+                marginLeft: '0.5em',
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.6875rem',
+                color: 'var(--accent)',
+                backgroundColor: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                padding: 0,
+              }}
+            >
+              {resultExpanded ? 'collapse' : 'expand'}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api/sse.ts
+++ b/frontend/lib/api/sse.ts
@@ -1,4 +1,4 @@
-import type { ChatEvent, Persona } from '@/types/api';
+import type { ChatEvent, ChatMessage, Persona } from '@/types/api';
 import { MOCK_MODE, ApiError } from './client';
 import { MOCK_CHAT_EVENTS } from './mocks';
 
@@ -13,7 +13,7 @@ export interface ChatStream {
 
 // ─── Mock stream ───────────────────────────────────────────────────────────
 
-function createMockStream(_message: string, _persona: Persona): ChatStream {
+function createMockStream(_message: string, _persona: Persona, _history: ChatMessage[]): ChatStream {
   let handler: ((event: ChatEvent) => void) | null = null;
   let cancelled = false;
   const timers: ReturnType<typeof setTimeout>[] = [];
@@ -48,7 +48,7 @@ function createMockStream(_message: string, _persona: Persona): ChatStream {
 
 // ─── Real stream (fetch-based SSE for POST) ────────────────────────────────
 
-function createRealStream(message: string, persona: Persona): ChatStream {
+function createRealStream(message: string, persona: Persona, history: ChatMessage[]): ChatStream {
   let handler: ((event: ChatEvent) => void) | null = null;
   let cancelled = false;
   const controller = new AbortController();
@@ -61,7 +61,7 @@ function createRealStream(message: string, persona: Persona): ChatStream {
       res = await fetch(`${base}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
-        body: JSON.stringify({ message, persona }),
+        body: JSON.stringify({ message, persona, history }),
         credentials: 'include',
         signal: controller.signal,
       });
@@ -134,7 +134,11 @@ function createRealStream(message: string, persona: Persona): ChatStream {
 
 // ─── Public factory ────────────────────────────────────────────────────────
 
-export function createChatStream(message: string, persona: Persona): ChatStream {
-  if (MOCK_MODE) return createMockStream(message, persona);
-  return createRealStream(message, persona);
+export function createChatStream(
+  message: string,
+  persona: Persona,
+  history: ChatMessage[] = [],
+): ChatStream {
+  if (MOCK_MODE) return createMockStream(message, persona, history);
+  return createRealStream(message, persona, history);
 }


### PR DESCRIPTION
Closes #49

Implements Story #49 — SSE streaming with tool-call transparency. Replaces the stub 500ms response from #48 with real streaming.

## What's included

### lib/api/sse.ts
- createChatStream now accepts history (last 10 ChatMessage[]) and includes it in the POST body

### components/chat/ToolCallCard.tsx (new)
- Three states: running (pulsing violet border + spinner), done (solid border + green checkmark + duration badge), error (red border)
- Collapsible args block on all states (▼/▲ toggle)
- Result preview: first 200 chars + click-to-expand for full result

### components/chat/MessageBubble.tsx
- Renders toolCalls above text content in a flex column

### app/(demo)/ask/page.tsx
- Full streaming: events mutate per-stream accumulator, flushed into React state via setMessages
- Cancel button (Square icon) swaps in during streaming, calls stream.cancel()
- Retry-once silently on first error; second error shows "Connection lost" banner with manual Retry
- 401 response → triggerReAuth(pendingQuestion) before retry logic
- Last 10 messages sent as history with each request
- Typing indicator only when assistant message has no content or tool calls yet

## Checks
- pnpm typecheck ✓
- pnpm lint ✓
- Works in MOCK_MODE=true — fixture stream from mocks.ts shows token streaming + 2 mock tool calls (search_codebase, get_function_context)