### PR TITLE
feat(graph): force-directed visualization for code clusters (#52)

### DIFF
--- a/frontend/app/(demo)/ask/page.tsx
+++ b/frontend/app/(demo)/ask/page.tsx
@@ -79,6 +79,18 @@ export default function AskPage() {
     }
   }, [loading, user, router]);
 
+  // G keyboard shortcut → navigate to graph (skip when textarea focused)
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key !== 'g' && e.key !== 'G') return;
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'TEXTAREA' || target.tagName === 'INPUT') return;
+      router.push('/graph');
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [router]);
+
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -640,6 +652,22 @@ export default function AskPage() {
             <span style={{ color: 'var(--text-muted)', textTransform: 'capitalize' }}>{persona}</span>
             {' · '}
             {isStreaming ? 'Streaming…' : 'Enter to send'}
+            {' · '}
+            Press{' '}
+            <kbd
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.625rem',
+                color: 'var(--text-dim)',
+                backgroundColor: 'var(--surface-elevated)',
+                border: '1px solid var(--border)',
+                borderRadius: '3px',
+                padding: '0.1em 0.35em',
+              }}
+            >
+              G
+            </kbd>
+            {' '}for graph view
           </p>
         </div>
       </div>

--- a/frontend/app/(demo)/graph/page.tsx
+++ b/frontend/app/(demo)/graph/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/lib/auth';
+import { getGraph, listRepos } from '@/lib/api/endpoints';
+import { DomainGraph } from '@/components/graph/DomainGraph';
+
+export default function GraphPage() {
+  const { user, loading, logout } = useAuth();
+  const router = useRouter();
+  const [selectedRepo, setSelectedRepo] = useState('');
+
+  const reposQuery = useQuery({
+    queryKey: ['repos'],
+    queryFn: () => listRepos(),
+  });
+
+  const graphQuery = useQuery({
+    queryKey: ['graph', selectedRepo],
+    queryFn: () => getGraph(selectedRepo || undefined),
+    staleTime: 60_000,
+  });
+
+  const repos = (reposQuery.data ?? []).map((r) => ({ id: r.id, name: r.name }));
+  const data = graphQuery.data;
+  const isEmpty = data && data.nodes.length === 0;
+
+  return (
+    <div
+      style={{
+        height: '100vh',
+        backgroundColor: 'var(--bg)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <header
+        style={{
+          height: '52px',
+          borderBottom: '1px solid var(--border)',
+          backgroundColor: 'var(--surface)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 1.5rem',
+          flexShrink: 0,
+          gap: '1rem',
+          zIndex: 5,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.8125rem',
+              color: 'var(--accent)',
+              letterSpacing: '0.08em',
+            }}
+          >
+            CodeLens
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.75rem',
+              color: 'var(--text-dim)',
+            }}
+          >
+            /
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.75rem',
+              color: 'var(--text-muted)',
+            }}
+          >
+            graph
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <Link
+            href="/ask"
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.75rem',
+              color: 'var(--text-dim)',
+              textDecoration: 'none',
+              backgroundColor: 'transparent',
+              border: '1px solid var(--border)',
+              borderRadius: '6px',
+              padding: '0.25rem 0.625rem',
+              transition: 'color 150ms, border-color 150ms',
+            }}
+          >
+            ← Ask
+          </Link>
+
+          {!loading && user && (
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.75rem',
+                color: 'var(--text-muted)',
+                backgroundColor: 'var(--surface-elevated)',
+                border: '1px solid var(--border)',
+                borderRadius: '6px',
+                padding: '0.25rem 0.625rem',
+              }}
+            >
+              {user.email}
+            </span>
+          )}
+          <button
+            onClick={() => {
+              void logout();
+              router.push('/login');
+            }}
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: '0.75rem',
+              color: 'var(--text-dim)',
+              backgroundColor: 'transparent',
+              border: '1px solid var(--border)',
+              borderRadius: '6px',
+              padding: '0.25rem 0.625rem',
+              cursor: 'pointer',
+            }}
+          >
+            Log out
+          </button>
+        </div>
+      </header>
+
+      {/* Graph area */}
+      <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+        {graphQuery.isLoading && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 2,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.875rem',
+                color: 'var(--text-dim)',
+              }}
+            >
+              Loading graph…
+            </span>
+          </div>
+        )}
+
+        {graphQuery.isError && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'column',
+              gap: '0.75rem',
+              zIndex: 2,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.9375rem',
+                color: 'var(--text-muted)',
+              }}
+            >
+              No graph data. Index a repository first.
+            </span>
+            {user?.role === 'admin' && (
+              <Link
+                href="/admin/repositories"
+                style={{
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: '0.8125rem',
+                  color: 'var(--accent)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: '2px',
+                }}
+              >
+                Go to Repositories →
+              </Link>
+            )}
+          </div>
+        )}
+
+        {isEmpty && !graphQuery.isLoading && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'column',
+              gap: '0.75rem',
+              zIndex: 2,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: '0.9375rem',
+                color: 'var(--text-muted)',
+              }}
+            >
+              No graph data. Index a repository first.
+            </span>
+            {user?.role === 'admin' && (
+              <Link
+                href="/admin/repositories"
+                style={{
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: '0.8125rem',
+                  color: 'var(--accent)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: '2px',
+                }}
+              >
+                Go to Repositories →
+              </Link>
+            )}
+          </div>
+        )}
+
+        {data && data.nodes.length > 0 && (
+          <DomainGraph
+            data={data}
+            repos={repos}
+            selectedRepo={selectedRepo}
+            onRepoChange={setSelectedRepo}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -145,3 +145,8 @@
   0%, 100% { border-color: var(--accent); }
   50% { border-color: rgba(139, 92, 246, 0.3); }
 }
+
+@keyframes slide-in-right {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}

--- a/frontend/components/graph/DomainGraph.tsx
+++ b/frontend/components/graph/DomainGraph.tsx
@@ -1,0 +1,609 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import type { GraphData, GraphNode, GraphEdge } from '@/types/api';
+
+// SSR-safe: canvas APIs aren't available server-side
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), { ssr: false });
+
+// ─── Domain colour helpers ──────────────────────────────────────────────────
+
+function domainColor(domainId: string, allDomainIds: string[]): string {
+  const idx = allDomainIds.indexOf(domainId);
+  const hue = (270 + idx * 30) % 360;
+  return `hsl(${hue}, 60%, 55%)`;
+}
+
+// ─── Node radius by degree ──────────────────────────────────────────────────
+
+function nodeRadius(degree: number, maxDegree: number): number {
+  if (maxDegree === 0) return 5;
+  const t = Math.sqrt(degree / maxDegree);
+  return 3 + t * 11;
+}
+
+// ─── Internal node shape (extends GraphNode with pre-computed display props) ─
+
+interface RichNode extends GraphNode {
+  x?: number;
+  y?: number;
+  __color: string;
+  __radius: number;
+}
+
+// ─── Side panel ─────────────────────────────────────────────────────────────
+
+interface SidePanelProps {
+  node: RichNode;
+  allNodes: RichNode[];
+  allEdges: GraphEdge[];
+  domainIds: string[];
+  onClose: () => void;
+  onNavigate: (nodeId: string) => void;
+}
+
+function SidePanel({ node, allNodes, allEdges, domainIds, onClose, onNavigate }: SidePanelProps) {
+  const neighborIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const e of allEdges) {
+      if (e.source === node.id) ids.add(e.target);
+      if (e.target === node.id) ids.add(e.source);
+    }
+    return ids;
+  }, [node.id, allEdges]);
+
+  const neighbors = allNodes.filter((n) => neighborIds.has(n.id));
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        width: '400px',
+        height: '100%',
+        backgroundColor: 'var(--surface)',
+        borderLeft: '1px solid var(--border)',
+        display: 'flex',
+        flexDirection: 'column',
+        zIndex: 20,
+        animation: 'slide-in-right 220ms ease-out',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: '1.25rem 1.25rem 1rem',
+          borderBottom: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '0.75rem',
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <h2
+            style={{
+              fontFamily: "'Instrument Serif', Georgia, serif",
+              fontSize: '1.375rem',
+              fontWeight: 400,
+              color: 'var(--text)',
+              margin: '0 0 0.25rem',
+              lineHeight: 1.2,
+              wordBreak: 'break-word',
+            }}
+          >
+            {node.label}
+          </h2>
+          <span
+            style={{
+              display: 'inline-block',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.6875rem',
+              color: 'var(--text-dim)',
+              backgroundColor: 'var(--surface-elevated)',
+              border: '1px solid var(--border)',
+              borderRadius: '4px',
+              padding: '0.15em 0.5em',
+            }}
+          >
+            {node.domain}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'var(--text-dim)',
+            fontSize: '1.125rem',
+            lineHeight: 1,
+            padding: '0.125rem',
+            flexShrink: 0,
+          }}
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '1rem 1.25rem' }}>
+        <div style={{ marginBottom: '1rem' }}>
+          <div style={labelStyle}>File</div>
+          <code style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8125rem', color: 'var(--text-muted)', wordBreak: 'break-all' }}>
+            {node.file}
+          </code>
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <div style={labelStyle}>Signature</div>
+          <pre
+            style={{
+              margin: 0,
+              padding: '0.625rem 0.75rem',
+              backgroundColor: 'var(--surface-elevated)',
+              border: '1px solid var(--border)',
+              borderRadius: '6px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.75rem',
+              color: 'var(--accent)',
+              overflowX: 'auto',
+              lineHeight: 1.5,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {node.signature}
+          </pre>
+        </div>
+
+        <div style={{ marginBottom: '1.25rem' }}>
+          <div style={labelStyle}>Domain</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span style={{ width: '10px', height: '10px', borderRadius: '50%', backgroundColor: domainColor(node.domainId, domainIds), flexShrink: 0 }} />
+            <span style={{ fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--text-muted)' }}>{node.domain}</span>
+          </div>
+        </div>
+
+        <div style={{ marginBottom: '1.25rem' }}>
+          <div style={labelStyle}>Connections</div>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.875rem', color: 'var(--text-muted)' }}>{node.degree}</span>
+        </div>
+
+        {neighbors.length > 0 && (
+          <div>
+            <div style={labelStyle}>Neighbors ({neighbors.length})</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+              {neighbors.slice(0, 20).map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => onNavigate(n.id)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    padding: '0.375rem 0.5rem',
+                    backgroundColor: 'transparent',
+                    border: '1px solid var(--border)',
+                    borderRadius: '5px',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                  }}
+                >
+                  <span style={{ width: '7px', height: '7px', borderRadius: '50%', backgroundColor: domainColor(n.domainId, domainIds), flexShrink: 0 }} />
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.75rem', color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {n.label}
+                  </span>
+                  <span style={{ fontFamily: 'var(--font-sans)', fontSize: '0.6875rem', color: 'var(--text-dim)', marginLeft: 'auto', flexShrink: 0 }}>
+                    {n.domain}
+                  </span>
+                </button>
+              ))}
+              {neighbors.length > 20 && (
+                <span style={{ fontFamily: 'var(--font-sans)', fontSize: '0.75rem', color: 'var(--text-dim)', padding: '0.25rem 0.5rem' }}>
+                  +{neighbors.length - 20} more
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: 'var(--font-sans)',
+  fontSize: '0.6875rem',
+  color: 'var(--text-dim)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  marginBottom: '0.25rem',
+};
+
+// ─── Controls ────────────────────────────────────────────────────────────────
+
+interface ControlsProps {
+  repos: { id: string; name: string }[];
+  selectedRepo: string;
+  onRepoChange: (id: string) => void;
+  domainIds: string[];
+  domainNames: Record<string, string>;
+  hiddenDomains: Set<string>;
+  onToggleDomain: (id: string) => void;
+  onResetView: () => void;
+}
+
+function Controls({ repos, selectedRepo, onRepoChange, domainIds, domainNames, hiddenDomains, onToggleDomain, onResetView }: ControlsProps) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '1rem',
+        left: '1rem',
+        zIndex: 10,
+        backgroundColor: 'rgba(20, 20, 20, 0.92)',
+        border: '1px solid var(--border)',
+        borderRadius: '8px',
+        padding: '0.875rem',
+        width: '220px',
+        backdropFilter: 'blur(8px)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.875rem',
+      }}
+    >
+      <div>
+        <div style={labelStyle}>Repository</div>
+        <select
+          value={selectedRepo}
+          onChange={(e) => onRepoChange(e.target.value)}
+          style={{
+            width: '100%',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.75rem',
+            color: 'var(--text-muted)',
+            backgroundColor: 'var(--surface-elevated)',
+            border: '1px solid var(--border)',
+            borderRadius: '5px',
+            padding: '0.375rem 0.5rem',
+            outline: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          <option value="">All repositories</option>
+          {repos.map((r) => (
+            <option key={r.id} value={r.id}>{r.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <div style={labelStyle}>Domains</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.3rem' }}>
+          {domainIds.map((id) => {
+            const hidden = hiddenDomains.has(id);
+            const color = domainColor(id, domainIds);
+            return (
+              <button
+                key={id}
+                onClick={() => onToggleDomain(id)}
+                title={domainNames[id]}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.3rem',
+                  padding: '0.2rem 0.45rem',
+                  borderRadius: '4px',
+                  border: `1px solid ${hidden ? 'var(--border)' : color}`,
+                  backgroundColor: hidden ? 'transparent' : `${color}22`,
+                  cursor: 'pointer',
+                  opacity: hidden ? 0.45 : 1,
+                  transition: 'opacity 150ms',
+                }}
+              >
+                <span style={{ width: '7px', height: '7px', borderRadius: '50%', backgroundColor: color, flexShrink: 0 }} />
+                <span style={{ fontFamily: 'var(--font-sans)', fontSize: '0.6rem', color: 'var(--text-dim)', maxWidth: '100px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {domainNames[id]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <button
+        onClick={onResetView}
+        style={{
+          fontFamily: 'var(--font-sans)',
+          fontSize: '0.75rem',
+          color: 'var(--text-muted)',
+          backgroundColor: 'var(--surface-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: '5px',
+          padding: '0.375rem 0.625rem',
+          cursor: 'pointer',
+          textAlign: 'center',
+        }}
+      >
+        Reset view
+      </button>
+    </div>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+interface DomainGraphProps {
+  data: GraphData;
+  repos: { id: string; name: string }[];
+  selectedRepo: string;
+  onRepoChange: (id: string) => void;
+}
+
+export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainGraphProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fgRef = useRef<any>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [selectedNode, setSelectedNode] = useState<RichNode | null>(null);
+  const [hiddenDomains, setHiddenDomains] = useState<Set<string>>(new Set());
+  const [canvasVisible, setCanvasVisible] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(([entry]) => {
+      const r = entry?.contentRect;
+      if (r) setDimensions({ width: r.width, height: r.height });
+    });
+    obs.observe(el);
+    setDimensions({ width: el.clientWidth, height: el.clientHeight });
+    return () => obs.disconnect();
+  }, []);
+
+  const domainIds = useMemo(
+    () => [...new Set(data.nodes.map((n) => n.domainId))].sort(),
+    [data.nodes],
+  );
+
+  const domainNames = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const n of data.nodes) map[n.domainId] = n.domain;
+    return map;
+  }, [data.nodes]);
+
+  const maxDegree = useMemo(
+    () => Math.max(1, ...data.nodes.map((n) => n.degree)),
+    [data.nodes],
+  );
+
+  const richNodes = useMemo<RichNode[]>(
+    () =>
+      data.nodes.map((n) => ({
+        ...n,
+        __color: domainColor(n.domainId, domainIds),
+        __radius: nodeRadius(n.degree, maxDegree),
+      })),
+    [data.nodes, domainIds, maxDegree],
+  );
+
+  const neighborSet = useMemo(() => {
+    if (!hoveredId) return new Set<string>();
+    const s = new Set<string>();
+    for (const e of data.edges) {
+      if (e.source === hoveredId) s.add(e.target);
+      if (e.target === hoveredId) s.add(e.source);
+    }
+    return s;
+  }, [hoveredId, data.edges]);
+
+  // react-force-graph-2d expects { nodes, links }
+  const fgData = useMemo(
+    () => ({
+      nodes: richNodes,
+      links: data.edges,
+    }),
+    [richNodes, data.edges],
+  );
+
+  const nodeCanvasObject = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (rawNode: any, ctx: CanvasRenderingContext2D) => {
+      const n = rawNode as RichNode;
+      const x: number = n.x ?? 0;
+      const y: number = n.y ?? 0;
+      const hidden = hiddenDomains.has(n.domainId);
+
+      let alpha = 1;
+      if (hidden) alpha = 0.05;
+      else if (hoveredId) {
+        if (n.id === hoveredId) alpha = 1;
+        else if (neighborSet.has(n.id)) alpha = 0.85;
+        else alpha = 0.12;
+      }
+
+      const r = n.__radius;
+
+      // Glow ring on hovered node
+      if (n.id === hoveredId && !hidden) {
+        const grd = ctx.createRadialGradient(x, y, r, x, y, r + 5);
+        grd.addColorStop(0, `${n.__color}55`);
+        grd.addColorStop(1, `${n.__color}00`);
+        ctx.beginPath();
+        ctx.arc(x, y, r + 5, 0, 2 * Math.PI);
+        ctx.fillStyle = grd;
+        ctx.fill();
+      }
+
+      ctx.globalAlpha = alpha;
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, 2 * Math.PI);
+      ctx.fillStyle = n.__color;
+      ctx.fill();
+      ctx.globalAlpha = 1;
+
+      // Label on hover
+      if (!hidden && hoveredId && (n.id === hoveredId || neighborSet.has(n.id))) {
+        const fontSize = Math.max(8, r * 0.9);
+        ctx.font = `${fontSize}px monospace`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillStyle = 'rgba(245,245,245,0.85)';
+        ctx.globalAlpha = alpha;
+        ctx.fillText(n.label.slice(0, 22), x, y + r + 3);
+        ctx.globalAlpha = 1;
+      }
+    },
+    [hoveredId, neighborSet, hiddenDomains],
+  );
+
+  const nodePointerAreaPaint = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (rawNode: any, color: string, ctx: CanvasRenderingContext2D) => {
+      const n = rawNode as RichNode;
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(n.x ?? 0, n.y ?? 0, n.__radius + 2, 0, 2 * Math.PI);
+      ctx.fill();
+    },
+    [],
+  );
+
+  const linkColor = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (link: any): string => {
+      const srcId = typeof link.source === 'object' ? link.source?.id : link.source;
+      const tgtId = typeof link.target === 'object' ? link.target?.id : link.target;
+      if (!hoveredId) return 'rgba(255,255,255,0.12)';
+      if (srcId === hoveredId || tgtId === hoveredId) return 'rgba(139,92,246,0.65)';
+      return 'rgba(255,255,255,0.04)';
+    },
+    [hoveredId],
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleNodeHover = useCallback((node: any) => {
+    setHoveredId(node ? (node as RichNode).id : null);
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleNodeClick = useCallback((node: any) => {
+    setSelectedNode(node as RichNode);
+  }, []);
+
+  const handleNavigate = useCallback(
+    (nodeId: string) => {
+      const n = richNodes.find((nd) => nd.id === nodeId);
+      if (!n) return;
+      setSelectedNode(n);
+      fgRef.current?.centerAt(n.x ?? 0, n.y ?? 0, 600);
+      fgRef.current?.zoom(2.5, 600);
+    },
+    [richNodes],
+  );
+
+  const handleResetView = useCallback(() => {
+    fgRef.current?.zoomToFit(400, 60);
+  }, []);
+
+  const toggleDomain = useCallback((id: string) => {
+    setHiddenDomains((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleEngineStop = useCallback(() => {
+    setCanvasVisible(true);
+    setTimeout(() => fgRef.current?.zoomToFit(400, 80), 50);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}
+    >
+      {/* Grain overlay */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: 1,
+          pointerEvents: 'none',
+          opacity: 0.04,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E")`,
+          backgroundRepeat: 'repeat',
+        }}
+      />
+
+      {/* Canvas fade-in wrapper */}
+      <div
+        style={{
+          opacity: canvasVisible ? 1 : 0,
+          transition: 'opacity 400ms ease-in',
+          position: 'absolute',
+          inset: 0,
+        }}
+      >
+        <ForceGraph2D
+          ref={fgRef}
+          graphData={fgData}
+          width={dimensions.width}
+          height={dimensions.height}
+          backgroundColor="#0a0a0a"
+          nodeId="id"
+          nodeCanvasObject={nodeCanvasObject}
+          nodeCanvasObjectMode={() => 'replace'}
+          nodePointerAreaPaint={nodePointerAreaPaint}
+          linkColor={linkColor}
+          linkWidth={1}
+          linkDirectionalArrowLength={0}
+          warmupTicks={300}
+          cooldownTicks={0}
+          onEngineStop={handleEngineStop}
+          onNodeHover={handleNodeHover}
+          onNodeClick={handleNodeClick}
+          enableNodeDrag
+          enableZoomInteraction
+          enablePanInteraction
+        />
+      </div>
+
+      <Controls
+        repos={repos}
+        selectedRepo={selectedRepo}
+        onRepoChange={onRepoChange}
+        domainIds={domainIds}
+        domainNames={domainNames}
+        hiddenDomains={hiddenDomains}
+        onToggleDomain={toggleDomain}
+        onResetView={handleResetView}
+      />
+
+      {selectedNode && (
+        <>
+          <div
+            style={{ position: 'absolute', inset: 0, zIndex: 19 }}
+            onClick={() => setSelectedNode(null)}
+          />
+          <SidePanel
+            node={selectedNode}
+            allNodes={richNodes}
+            allEdges={data.edges}
+            domainIds={domainIds}
+            onClose={() => setSelectedNode(null)}
+            onNavigate={handleNavigate}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -28,7 +28,7 @@ export function middleware(request: NextRequest): NextResponse {
   const token = request.cookies.get(COOKIE_NAME)?.value;
 
   const isAdminPath = pathname.startsWith('/admin');
-  const isDemoPath = pathname.startsWith('/ask');
+  const isDemoPath = pathname.startsWith('/ask') || pathname.startsWith('/graph');
 
   if (!isAdminPath && !isDemoPath) {
     return NextResponse.next();
@@ -68,5 +68,5 @@ export function middleware(request: NextRequest): NextResponse {
 }
 
 export const config = {
-  matcher: ['/admin/:path*', '/ask/:path*'],
+  matcher: ['/admin/:path*', '/ask/:path*', '/graph/:path*', '/graph'],
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "prismjs": "^1.30.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-force-graph-2d": "^1.29.1",
     "shadcn": "^4.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@19.1.0)
       shadcn:
         specifier: ^4.7.0
         version: 4.7.0(@types/node@20.19.41)(typescript@5.9.3)
@@ -805,6 +808,9 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1006,6 +1012,10 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1120,6 +1130,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -1166,6 +1179,10 @@ packages:
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1273,6 +1290,82 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1679,9 +1772,17 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -1857,12 +1958,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -2052,6 +2161,10 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -2104,6 +2217,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2207,6 +2324,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2517,6 +2637,9 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2569,8 +2692,20 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -2856,6 +2991,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -3736,6 +3874,8 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -3924,6 +4064,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  accessor-fn@1.5.3: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4051,6 +4193,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.30: {}
 
+  bezier-js@6.1.4: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -4112,6 +4256,10 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001792: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   chalk@4.1.2:
     dependencies:
@@ -4193,6 +4341,83 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-binarytree@1.0.2: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -4765,9 +4990,33 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.29.1
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -4931,6 +5180,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  index-array-by@1.4.2: {}
+
   inherits@2.0.4: {}
 
   internal-slot@1.1.0:
@@ -4938,6 +5189,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ip-address@10.2.0: {}
 
@@ -5106,6 +5359,8 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jerrypick@1.1.2: {}
+
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
@@ -5148,6 +5403,10 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
 
   keyv@4.5.4:
     dependencies:
@@ -5222,6 +5481,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -5536,6 +5797,8 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  preact@10.29.1: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
@@ -5584,7 +5847,19 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-force-graph-2d@1.29.1(react@19.1.0):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-kapsule: 2.5.7(react@19.1.0)
+
   react-is@16.13.1: {}
+
+  react-kapsule@2.5.7(react@19.1.0):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 19.1.0
 
   react@19.1.0: {}
 
@@ -5981,6 +6256,8 @@ snapshots:
   tapable@2.3.3: {}
 
   tiny-invariant@1.3.3: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
Closes #52

Implements Story #52 — Force-directed graph visualization. The "wow factor" piece justifying the pivot from Streamlit.

## What's included

### /graph route
- Full-bleed canvas, auth-protected via middleware (added /graph to matcher and isDemoPath)

### DomainGraph component
- 300-tick simulation warmup before first paint — graph arrives settled, no jitter
- Canvas fades in over 400ms
- Nodes colored by domain via HSL rotation starting at violet (hue 270), +30° per domain, 12 distinct colors
- Radius = 3 + sqrt(degree/max) * 11 px — perceptually scaled, min 3 / max 14
- Custom nodeCanvasObject: circle + glow ring on hovered, labels above hovered/neighbor nodes only
- Hover state: hovered + neighbors at full opacity, rest at 0.12; connected edges turn violet at 0.65, others at 0.04
- Click opens side panel: Instrument Serif name, file path (mono), signature code block, domain swatch, clickable neighbors list (pans and zooms to target)
- CSS grain overlay (SVG feTurbulence) adds depth against #0a0a0a background

### Controls overlay (top-left)
- Repository dropdown (3 mock repos)
- Domain filter chips with color swatches — multi-select, hidden domains dim to 0.05
- Reset view button (zoom to fit)

### /ask integration
- G key navigates to /graph (skipped when textarea is focused)
- Footer hint: "Press G for graph view"

## Checks
- pnpm typecheck ✓
- pnpm lint ✓
- Works in MOCK_MODE=true with the 193 nodes / ~400 edges fixture from #47