### PR TITLE
fix: polish pass across all merged stories (#41-#53)

### DIFF
--- a/frontend/app/(admin)/admin/dashboard/page.tsx
+++ b/frontend/app/(admin)/admin/dashboard/page.tsx
@@ -7,13 +7,13 @@ import { JobsTable } from '@/components/admin/JobsTable';
 import { HealthCard } from '@/components/admin/HealthCard';
 
 export default function DashboardPage() {
-  const { data: stats, isLoading: statsLoading } = useQuery({
+  const { data: stats, isLoading: statsLoading, isError: statsError } = useQuery({
     queryKey: ['stats'],
     queryFn: getStats,
     refetchOnWindowFocus: true,
   });
 
-  const { data: jobs = [], isLoading: jobsLoading } = useQuery({
+  const { data: jobs = [], isLoading: jobsLoading, isError: jobsError } = useQuery({
     queryKey: ['jobs', 10],
     queryFn: () => listJobs(10),
     refetchOnWindowFocus: true,
@@ -52,6 +52,13 @@ export default function DashboardPage() {
           System overview and recent indexing activity
         </p>
       </div>
+
+      {/* Stats error */}
+      {statsError && (
+        <div style={{ marginBottom: '1rem', padding: '0.75rem 1rem', backgroundColor: 'var(--surface)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: '8px', fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--danger)' }}>
+          Failed to load system stats. Check your connection and try again.
+        </div>
+      )}
 
       {/* KPI row */}
       <div
@@ -99,7 +106,7 @@ export default function DashboardPage() {
           alignItems: 'start',
         }}
       >
-        <JobsTable jobs={jobs} isLoading={jobsLoading} />
+        <JobsTable jobs={jobs} isLoading={jobsLoading} isError={jobsError} />
         <HealthCard stats={stats} isLoading={statsLoading} />
       </div>
     </div>

--- a/frontend/app/(admin)/admin/domains/page.tsx
+++ b/frontend/app/(admin)/admin/domains/page.tsx
@@ -23,7 +23,7 @@ export default function DomainsPage() {
 
   const domainQueryKey = ['domains', repoFilter];
 
-  const { data: domains = [], isLoading: domainsLoading } = useQuery({
+  const { data: domains = [], isLoading: domainsLoading, isError: domainsError } = useQuery({
     queryKey: domainQueryKey,
     queryFn: () => listDomains(repoFilter || undefined),
     refetchOnWindowFocus: true,
@@ -158,7 +158,11 @@ export default function DomainsPage() {
       </div>
 
       {/* Domain grid */}
-      {domainsLoading ? (
+      {domainsError ? (
+        <div style={{ padding: '0.75rem 1rem', backgroundColor: 'var(--surface)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: '8px', fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--danger)' }}>
+          Failed to load domains. Check your connection and try again.
+        </div>
+      ) : domainsLoading ? (
         <div
           style={{
             display: 'grid',

--- a/frontend/app/(admin)/admin/domains/page.tsx
+++ b/frontend/app/(admin)/admin/domains/page.tsx
@@ -142,10 +142,14 @@ export default function DomainsPage() {
             backgroundColor: 'var(--surface)',
             border: '1px solid var(--border)',
             borderRadius: '6px',
-            padding: '0.375rem 0.75rem',
+            padding: '0.375rem 2rem 0.375rem 0.75rem',
             cursor: 'pointer',
             outline: 'none',
             minWidth: '180px',
+            appearance: 'none',
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23525252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'right 0.625rem center',
           }}
         >
           <option value="">All repositories</option>

--- a/frontend/app/(admin)/admin/repositories/[id]/page.tsx
+++ b/frontend/app/(admin)/admin/repositories/[id]/page.tsx
@@ -16,12 +16,12 @@ interface PageProps {
 export default function RepoDetailPage({ params }: PageProps) {
   const { id } = use(params);
 
-  const { data: repos = [], isLoading: reposLoading } = useQuery({
+  const { data: repos = [], isLoading: reposLoading, isError: reposError } = useQuery({
     queryKey: ['repos'],
     queryFn: listRepos,
   });
 
-  const { data: jobs = [], isLoading: jobsLoading } = useQuery({
+  const { data: jobs = [], isLoading: jobsLoading, isError: jobsError } = useQuery({
     queryKey: ['jobs', 50],
     queryFn: () => listJobs(50),
   });
@@ -33,6 +33,14 @@ export default function RepoDetailPage({ params }: PageProps) {
 
   const repo = repos.find((r) => r.id === id);
   const repoJobs = jobs.filter((j) => j.repoId === id);
+
+  if (reposError) {
+    return (
+      <div style={{ padding: '2rem', maxWidth: '1400px', margin: '0 auto', fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--danger)' }}>
+        Failed to load repository data. Check your connection and try again.
+      </div>
+    );
+  }
 
   if (!reposLoading && !repo) {
     return (
@@ -251,7 +259,7 @@ export default function RepoDetailPage({ params }: PageProps) {
         >
           Indexing history
         </h2>
-        <JobsTable jobs={repoJobs} isLoading={jobsLoading} />
+        <JobsTable jobs={repoJobs} isLoading={jobsLoading} isError={jobsError} />
       </div>
     </div>
   );

--- a/frontend/app/(admin)/admin/repositories/page.tsx
+++ b/frontend/app/(admin)/admin/repositories/page.tsx
@@ -66,6 +66,7 @@ function AddRepoDialog({ open, onOpenChange, onAdd, isPending }: AddDialogProps)
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               required
+              autoFocus
             />
           </div>
           <div>
@@ -153,6 +154,7 @@ function DeleteRepoDialog({ repo, open, onOpenChange, onConfirm, isPending }: De
               placeholder={repo?.name ?? ''}
               value={typed}
               onChange={(e) => setTyped(e.target.value)}
+              autoFocus
             />
           </div>
           <DialogFooter>

--- a/frontend/app/(admin)/admin/repositories/page.tsx
+++ b/frontend/app/(admin)/admin/repositories/page.tsx
@@ -111,59 +111,34 @@ interface DeleteDialogProps {
 }
 
 function DeleteRepoDialog({ repo, open, onOpenChange, onConfirm, isPending }: DeleteDialogProps) {
-  const [typed, setTyped] = useState('');
-  const matches = typed === repo?.name;
-
   return (
-    <Dialog open={open} onOpenChange={(v: boolean) => { onOpenChange(v); if (!v) setTyped(''); }}>
-      <DialogContent style={{ maxWidth: '440px' }}>
+    <Dialog open={open} onOpenChange={(v: boolean) => onOpenChange(v)}>
+      <DialogContent style={{ maxWidth: '420px' }}>
         <DialogHeader>
           <DialogTitle>Delete repository</DialogTitle>
         </DialogHeader>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.875rem' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           <p
             style={{
               fontFamily: 'var(--font-sans)',
               fontSize: '0.875rem',
               color: 'var(--text-muted)',
               lineHeight: 1.6,
+              margin: 0,
             }}
           >
-            This will permanently delete{' '}
-            <span
-              style={{ fontFamily: 'var(--font-mono)', color: 'var(--text)', fontSize: '0.8125rem' }}
-            >
+            Permanently delete{' '}
+            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text)', fontSize: '0.8125rem' }}>
               {repo?.name}
             </span>{' '}
-            and all its indexed data. This action cannot be undone.
+            and all its indexed data? This cannot be undone.
           </p>
-          <div>
-            <label
-              style={{
-                display: 'block',
-                fontFamily: 'var(--font-sans)',
-                fontSize: '0.8125rem',
-                color: 'var(--text-muted)',
-                marginBottom: '0.375rem',
-              }}
-            >
-              Type <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text)' }}>{repo?.name}</span> to confirm
-            </label>
-            <Input
-              type="text"
-              placeholder={repo?.name ?? ''}
-              value={typed}
-              onChange={(e) => setTyped(e.target.value)}
-              autoFocus
-            />
-          </div>
           <DialogFooter>
-            <Button
-              variant="destructive"
-              disabled={!matches || isPending}
-              onClick={onConfirm}
-            >
-              {isPending ? 'Deleting…' : 'Delete repository'}
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" disabled={isPending} onClick={onConfirm}>
+              {isPending ? 'Deleting…' : 'Delete'}
             </Button>
           </DialogFooter>
         </div>

--- a/frontend/app/(admin)/admin/repositories/page.tsx
+++ b/frontend/app/(admin)/admin/repositories/page.tsx
@@ -181,7 +181,7 @@ export default function RepositoriesPage() {
   const [addOpen, setAddOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Repository | null>(null);
 
-  const { data: repos = [], isLoading } = useQuery({
+  const { data: repos = [], isLoading, isError } = useQuery({
     queryKey: ['repos'],
     queryFn: listRepos,
     refetchOnWindowFocus: true,
@@ -270,6 +270,13 @@ export default function RepositoriesPage() {
           Add repository
         </Button>
       </div>
+
+      {/* Error state */}
+      {isError && (
+        <div style={{ marginBottom: '1rem', padding: '0.75rem 1rem', backgroundColor: 'var(--surface)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: '8px', fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--danger)' }}>
+          Failed to load repositories. Check your connection and try again.
+        </div>
+      )}
 
       {/* Table */}
       <div style={{ animation: 'fade-up 300ms ease-out 50ms both' }}>

--- a/frontend/app/(admin)/admin/users/page.tsx
+++ b/frontend/app/(admin)/admin/users/page.tsx
@@ -402,7 +402,7 @@ export default function UsersPage() {
   const [roleTarget, setRoleTarget] = useState<User | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
 
-  const { data: users = [], isLoading } = useQuery({
+  const { data: users = [], isLoading, isError } = useQuery({
     queryKey: ['users'],
     queryFn: listUsers,
     refetchOnWindowFocus: true,
@@ -493,6 +493,10 @@ export default function UsersPage() {
               <Skeleton key={i} className="h-10 w-full" />
             ))}
           </div>
+        ) : isError ? (
+          <div style={{ padding: '2rem', textAlign: 'center', fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--danger)' }}>
+            Failed to load users. Check your connection and try again.
+          </div>
         ) : (
           <Table>
             <TableHeader>
@@ -569,6 +573,7 @@ export default function UsersPage() {
                     <TableCell>
                       <DropdownMenu>
                         <DropdownMenuTrigger
+                          aria-label={`Actions for ${u.email}`}
                           style={{
                             display: 'flex',
                             alignItems: 'center',

--- a/frontend/app/(admin)/admin/users/page.tsx
+++ b/frontend/app/(admin)/admin/users/page.tsx
@@ -186,6 +186,7 @@ function AddUserDialog({ open, onOpenChange }: AddUserDialogProps) {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
+                autoFocus
               />
             </div>
             <DialogFooter>

--- a/frontend/app/(admin)/admin/users/page.tsx
+++ b/frontend/app/(admin)/admin/users/page.tsx
@@ -590,13 +590,13 @@ export default function UsersPage() {
                           <MoreHorizontal size={15} />
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <DropdownMenuItem onSelect={() => setResetTarget(u)}>
+                          <DropdownMenuItem onClick={() => setResetTarget(u)}>
                             Reset password
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             disabled={isSelf}
                             title={isSelf ? 'You cannot change your own role' : undefined}
-                            onSelect={() => !isSelf && setRoleTarget(u)}
+                            onClick={() => setRoleTarget(u)}
                           >
                             {u.role === 'admin' ? 'Demote to user' : 'Promote to admin'}
                           </DropdownMenuItem>
@@ -605,7 +605,7 @@ export default function UsersPage() {
                             variant="destructive"
                             disabled={isSelf}
                             title={isSelf ? 'You cannot delete your own account' : undefined}
-                            onSelect={() => !isSelf && setDeleteTarget(u)}
+                            onClick={() => setDeleteTarget(u)}
                           >
                             Delete
                           </DropdownMenuItem>

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import type { User } from '@/types/api';
@@ -33,7 +33,6 @@ function friendlyError(raw: string, status: number): string {
 // ─── Page ──────────────────────────────────────────────────────────────────
 
 export default function LoginPage() {
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const reason = searchParams.get('reason');
@@ -74,17 +73,11 @@ export default function LoginPage() {
       return;
     }
 
-    const role = result.user.role;
-    if (role === 'admin') {
-      // Honour the `from` param only for admin-safe destinations
-      if (from && from.startsWith('/admin')) {
-        router.push('/admin/dashboard');
-      } else {
-        router.push('/admin/dashboard');
-      }
-    } else {
-      router.push('/ask');
-    }
+    // Full-page navigation so AuthProvider remounts and re-fetches /api/auth/me
+    // with the new cookie. Soft navigation (router.push) keeps the stale auth
+    // state from the previous session and triggers the "!user → /login" guard.
+    const dest = result.user.role === 'admin' ? '/admin/dashboard' : '/ask';
+    window.location.assign(dest);
   }
 
   return (

--- a/frontend/app/(demo)/ask/page.tsx
+++ b/frontend/app/(demo)/ask/page.tsx
@@ -79,6 +79,13 @@ export default function AskPage() {
     }
   }, [loading, user, router]);
 
+  // Cancel any active stream when the component unmounts
+  useEffect(() => {
+    return () => {
+      activeStreamRef.current?.cancel();
+    };
+  }, []);
+
   // G keyboard shortcut → navigate to graph (skip when textarea focused)
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -609,7 +616,7 @@ export default function AskPage() {
                   justifyContent: 'center',
                   flexShrink: 0,
                 }}
-                title="Cancel"
+                aria-label="Cancel"
               >
                 <Square size={14} />
               </button>
@@ -617,6 +624,7 @@ export default function AskPage() {
               <button
                 onClick={() => submitMessage(inputValue)}
                 disabled={!inputValue.trim() || isStreaming}
+                aria-label="Send message"
                 style={{
                   width: '38px',
                   height: '38px',

--- a/frontend/components/admin/DomainCard.tsx
+++ b/frontend/components/admin/DomainCard.tsx
@@ -100,7 +100,7 @@ export function DomainCard({ domain, isRegenerating, onSave, onRegenerate }: Dom
         style={{
           position: 'absolute',
           top: '0.75rem',
-          right: '2.25rem',
+          right: '3rem',
           display: 'flex',
           alignItems: 'center',
           gap: '0.375rem',

--- a/frontend/components/admin/JobsTable.tsx
+++ b/frontend/components/admin/JobsTable.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 interface JobsTableProps {
   jobs: IndexingJob[];
   isLoading: boolean;
+  isError?: boolean;
 }
 
 const STATUS_STYLES: Record<
@@ -61,7 +62,7 @@ function formatRelative(iso: string) {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-export function JobsTable({ jobs, isLoading }: JobsTableProps) {
+export function JobsTable({ jobs, isLoading, isError }: JobsTableProps) {
   return (
     <div
       style={{
@@ -91,6 +92,10 @@ export function JobsTable({ jobs, isLoading }: JobsTableProps) {
           {Array.from({ length: 5 }).map((_, i) => (
             <Skeleton key={i} className="h-8 w-full" />
           ))}
+        </div>
+      ) : isError ? (
+        <div style={{ padding: '2rem', textAlign: 'center', fontFamily: 'var(--font-sans)', fontSize: '0.875rem', color: 'var(--danger)' }}>
+          Failed to load jobs
         </div>
       ) : (
         <Table>

--- a/frontend/components/admin/ReposTable.tsx
+++ b/frontend/components/admin/ReposTable.tsx
@@ -172,14 +172,14 @@ export function ReposTable({ repos, isLoading, onView, onReindex, onDelete }: Re
                         <MoreHorizontal size={15} />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem onSelect={() => onView(repo)}>
+                        <DropdownMenuItem onClick={() => onView(repo)}>
                           View detail
                         </DropdownMenuItem>
-                        <DropdownMenuItem onSelect={() => onReindex(repo)}>
+                        <DropdownMenuItem onClick={() => onReindex(repo)}>
                           Re-index
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(repo)}>
+                        <DropdownMenuItem variant="destructive" onClick={() => onDelete(repo)}>
                           Delete
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/frontend/components/admin/ReposTable.tsx
+++ b/frontend/components/admin/ReposTable.tsx
@@ -155,6 +155,7 @@ export function ReposTable({ repos, isLoading, onView, onReindex, onDelete }: Re
                   <TableCell>
                     <DropdownMenu>
                       <DropdownMenuTrigger
+                        aria-label={`Actions for ${repo.name}`}
                         style={{
                           display: 'flex',
                           alignItems: 'center',

--- a/frontend/components/chat/DomainSidebar.tsx
+++ b/frontend/components/chat/DomainSidebar.tsx
@@ -49,7 +49,7 @@ export function DomainSidebar({ onInsertPrompt }: DomainSidebarProps) {
       >
         <button
           onClick={() => setCollapsed(false)}
-          title="Expand domain browser"
+          aria-label="Expand domain browser"
           style={{
             width: '28px',
             height: '28px',
@@ -112,7 +112,7 @@ export function DomainSidebar({ onInsertPrompt }: DomainSidebarProps) {
         </span>
         <button
           onClick={() => setCollapsed(true)}
-          title="Collapse domain browser"
+          aria-label="Collapse domain browser"
           style={{
             width: '24px',
             height: '24px',
@@ -147,6 +147,7 @@ export function DomainSidebar({ onInsertPrompt }: DomainSidebarProps) {
           <input
             type="text"
             placeholder="Filter domains…"
+            aria-label="Filter domains"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             style={{

--- a/frontend/components/chat/PersonaToggle.tsx
+++ b/frontend/components/chat/PersonaToggle.tsx
@@ -37,7 +37,7 @@ export function PersonaToggle({ value, onChange }: PersonaToggleProps) {
   const hoveredOption = OPTIONS.find((o) => o.value === hovered);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.25rem' }}>
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
       {/* Segmented control */}
       <div
         style={{
@@ -76,15 +76,25 @@ export function PersonaToggle({ value, onChange }: PersonaToggleProps) {
         })}
       </div>
 
-      {/* Hover description */}
+      {/* Hover description — floats below the header, doesn't affect layout */}
       <div
         style={{
-          height: '1rem',
+          position: 'absolute',
+          top: 'calc(100% + 8px)',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          whiteSpace: 'nowrap',
           fontFamily: 'var(--font-sans)',
-          fontSize: '0.6875rem',
-          color: 'var(--text-dim)',
+          fontSize: '0.75rem',
+          color: 'var(--text-muted)',
+          backgroundColor: 'var(--surface-elevated)',
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          padding: '0.3rem 0.625rem',
+          pointerEvents: 'none',
           transition: 'opacity 150ms',
           opacity: hoveredOption ? 1 : 0,
+          zIndex: 50,
         }}
       >
         {hoveredOption?.desc ?? ''}

--- a/frontend/components/graph/DomainGraph.tsx
+++ b/frontend/components/graph/DomainGraph.tsx
@@ -366,6 +366,23 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
     return () => obs.disconnect();
   }, []);
 
+  // Reset transient state when dataset changes (repo switch)
+  useEffect(() => {
+    setSelectedNode(null);
+    setHiddenDomains(new Set());
+    setHoveredId(null);
+  }, [data]);
+
+  // ESC closes the side panel
+  useEffect(() => {
+    if (!selectedNode) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setSelectedNode(null);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selectedNode]);
+
   const domainIds = useMemo(
     () => [...new Set(data.nodes.map((n) => n.domainId))].sort(),
     [data.nodes],
@@ -524,6 +541,13 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
     setCanvasVisible(true);
     setTimeout(() => fgRef.current?.zoomToFit(400, 80), 50);
   }, []);
+
+  // On repo switch the canvas is already visible; re-fit after simulation settles
+  useEffect(() => {
+    if (!canvasVisible) return;
+    const timer = setTimeout(() => fgRef.current?.zoomToFit(400, 80), 400);
+    return () => clearTimeout(timer);
+  }, [data, canvasVisible]);
 
   return (
     <div

--- a/frontend/components/graph/DomainGraph.tsx
+++ b/frontend/components/graph/DomainGraph.tsx
@@ -15,6 +15,10 @@ function domainColor(domainId: string, allDomainIds: string[]): string {
   return `hsl(${hue}, 60%, 55%)`;
 }
 
+function withAlpha(hslColor: string, alpha: number): string {
+  return hslColor.replace('hsl(', 'hsla(').replace(')', `, ${alpha})`);
+}
+
 // ─── Node radius by degree ──────────────────────────────────────────────────
 
 function nodeRadius(degree: number, maxDegree: number): number {
@@ -47,8 +51,11 @@ function SidePanel({ node, allNodes, allEdges, domainIds, onClose, onNavigate }:
   const neighborIds = useMemo(() => {
     const ids = new Set<string>();
     for (const e of allEdges) {
-      if (e.source === node.id) ids.add(e.target);
-      if (e.target === node.id) ids.add(e.source);
+      // e.source / e.target may be a string ID or a mutated node object
+      const src = typeof e.source === 'object' ? (e.source as { id: string }).id : e.source;
+      const tgt = typeof e.target === 'object' ? (e.target as { id: string }).id : e.target;
+      if (src === node.id) ids.add(tgt);
+      if (tgt === node.id) ids.add(src);
     }
     return ids;
   }, [node.id, allEdges]);
@@ -269,9 +276,13 @@ function Controls({ repos, selectedRepo, onRepoChange, domainIds, domainNames, h
             backgroundColor: 'var(--surface-elevated)',
             border: '1px solid var(--border)',
             borderRadius: '5px',
-            padding: '0.375rem 0.5rem',
+            padding: '0.375rem 1.75rem 0.375rem 0.5rem',
             outline: 'none',
             cursor: 'pointer',
+            appearance: 'none',
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23525252' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'right 0.5rem center',
           }}
         >
           <option value="">All repositories</option>
@@ -335,6 +346,66 @@ function Controls({ repos, selectedRepo, onRepoChange, domainIds, domainNames, h
   );
 }
 
+// ─── Zoom controls ──────────────────────────────────────────────────────────
+
+interface ZoomControlsProps {
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onReset: () => void;
+}
+
+const zoomBtnStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: 'var(--text-muted)',
+  fontFamily: 'var(--font-mono)',
+  fontSize: '0.875rem',
+  padding: '0.375rem 0.625rem',
+  lineHeight: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'color 120ms',
+};
+
+function ZoomControls({ onZoomIn, onZoomOut, onReset }: ZoomControlsProps) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: '1rem',
+        right: '1rem',
+        zIndex: 10,
+        display: 'flex',
+        alignItems: 'center',
+        backgroundColor: 'rgba(20, 20, 20, 0.92)',
+        border: '1px solid var(--border)',
+        borderRadius: '6px',
+        backdropFilter: 'blur(8px)',
+        overflow: 'hidden',
+      }}
+    >
+      <button onClick={onZoomOut} style={zoomBtnStyle} aria-label="Zoom out" title="Zoom out">
+        −
+      </button>
+      <div style={{ width: '1px', height: '16px', backgroundColor: 'var(--border)' }} />
+      <button
+        onClick={onReset}
+        style={{ ...zoomBtnStyle, minWidth: '46px', fontSize: '0.6875rem' }}
+        aria-label="Fit graph"
+        title="Fit graph"
+      >
+        Fit
+      </button>
+      <div style={{ width: '1px', height: '16px', backgroundColor: 'var(--border)' }} />
+      <button onClick={onZoomIn} style={zoomBtnStyle} aria-label="Zoom in" title="Zoom in">
+        +
+      </button>
+    </div>
+  );
+}
+
 // ─── Main component ──────────────────────────────────────────────────────────
 
 interface DomainGraphProps {
@@ -353,6 +424,7 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
   const [selectedNode, setSelectedNode] = useState<RichNode | null>(null);
   const [hiddenDomains, setHiddenDomains] = useState<Set<string>>(new Set());
   const [canvasVisible, setCanvasVisible] = useState(false);
+  const zoomRef = useRef(1);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -419,11 +491,13 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
     return s;
   }, [hoveredId, data.edges]);
 
-  // react-force-graph-2d expects { nodes, links }
+  // react-force-graph-2d mutates link objects (source/target: string → object).
+  // Cloning prevents the mutation from corrupting TanStack Query's cached data,
+  // which would break the force simulation on every subsequent repo switch.
   const fgData = useMemo(
     () => ({
       nodes: richNodes,
-      links: data.edges,
+      links: data.edges.map((e) => ({ ...e })),
     }),
     [richNodes, data.edges],
   );
@@ -449,8 +523,8 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
       // Glow ring on hovered node
       if (n.id === hoveredId && !hidden) {
         const grd = ctx.createRadialGradient(x, y, r, x, y, r + 5);
-        grd.addColorStop(0, `${n.__color}55`);
-        grd.addColorStop(1, `${n.__color}00`);
+        grd.addColorStop(0, withAlpha(n.__color, 0.33));
+        grd.addColorStop(1, withAlpha(n.__color, 0));
         ctx.beginPath();
         ctx.arc(x, y, r + 5, 0, 2 * Math.PI);
         ctx.fillStyle = grd;
@@ -496,9 +570,9 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
     (link: any): string => {
       const srcId = typeof link.source === 'object' ? link.source?.id : link.source;
       const tgtId = typeof link.target === 'object' ? link.target?.id : link.target;
-      if (!hoveredId) return 'rgba(255,255,255,0.12)';
-      if (srcId === hoveredId || tgtId === hoveredId) return 'rgba(139,92,246,0.65)';
-      return 'rgba(255,255,255,0.04)';
+      if (!hoveredId) return 'rgba(255,255,255,0.22)';
+      if (srcId === hoveredId || tgtId === hoveredId) return 'rgba(139,92,246,0.75)';
+      return 'rgba(255,255,255,0.06)';
     },
     [hoveredId],
   );
@@ -535,6 +609,38 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
       else next.add(id);
       return next;
     });
+  }, []);
+
+  const handleZoom = useCallback(({ k }: { k: number; x: number; y: number }) => {
+    zoomRef.current = k;
+  }, []);
+
+  const onRenderFramePre = useCallback((ctx: CanvasRenderingContext2D) => {
+    const w = ctx.canvas.width;
+    const h = ctx.canvas.height;
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    ctx.fillStyle = '#111116';
+    ctx.fillRect(0, 0, w, h);
+
+    // Fine grid (40 px)
+    ctx.beginPath();
+    ctx.strokeStyle = 'rgba(255,255,255,0.04)';
+    ctx.lineWidth = 0.5;
+    for (let x = 0; x <= w; x += 40) { ctx.moveTo(x, 0); ctx.lineTo(x, h); }
+    for (let y = 0; y <= h; y += 40) { ctx.moveTo(0, y); ctx.lineTo(w, y); }
+    ctx.stroke();
+
+    // Coarse grid (200 px)
+    ctx.beginPath();
+    ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+    ctx.lineWidth = 0.5;
+    for (let x = 0; x <= w; x += 200) { ctx.moveTo(x, 0); ctx.lineTo(x, h); }
+    for (let y = 0; y <= h; y += 200) { ctx.moveTo(0, y); ctx.lineTo(w, y); }
+    ctx.stroke();
+
+    ctx.restore();
   }, []);
 
   const handleEngineStop = useCallback(() => {
@@ -582,16 +688,18 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
           graphData={fgData}
           width={dimensions.width}
           height={dimensions.height}
-          backgroundColor="#0a0a0a"
+          backgroundColor="#111116"
           nodeId="id"
           nodeCanvasObject={nodeCanvasObject}
           nodeCanvasObjectMode={() => 'replace'}
           nodePointerAreaPaint={nodePointerAreaPaint}
           linkColor={linkColor}
-          linkWidth={1}
+          linkWidth={1.5}
           linkDirectionalArrowLength={0}
           warmupTicks={300}
           cooldownTicks={0}
+          onRenderFramePre={onRenderFramePre}
+          onZoom={handleZoom}
           onEngineStop={handleEngineStop}
           onNodeHover={handleNodeHover}
           onNodeClick={handleNodeClick}
@@ -611,6 +719,14 @@ export function DomainGraph({ data, repos, selectedRepo, onRepoChange }: DomainG
         onToggleDomain={toggleDomain}
         onResetView={handleResetView}
       />
+
+      {canvasVisible && (
+        <ZoomControls
+          onZoomIn={() => fgRef.current?.zoom(zoomRef.current * 1.25, 200)}
+          onZoomOut={() => fgRef.current?.zoom(zoomRef.current / 1.25, 200)}
+          onReset={handleResetView}
+        />
+      )}
 
       {selectedNode && (
         <>


### PR DESCRIPTION
Closes #64 

QA polish pass on all merged frontend stories. Cross-cutting bug fixes, accessibility, error states, and consistency.

## Graph (#52)
- **Crash fix:** Canvas gradient invalid CSS color (`hsl(...)55`) — added `withAlpha()` helper converting `hsl()` → `hsla(..., alpha)`. Hover glow now works.
- **Edge mutation bug:** react-force-graph-2d mutates `links` array (string IDs → node objects). TanStack Query cached the same reference, so repo switch left stale node references and the simulation lost edges. Fix: shallow-clone edges on every render.
- **Link visibility:** Default opacity 0.12 → 0.22, width 1 → 1.5
- **Side panel neighbors:** Edge comparison broke after mutation (object vs string). Added guard handling both shapes.
- **Grid background:** `onRenderFramePre` callback draws static screen-space grid (40px thin / 200px thick lines, white 4-8% opacity) on `#111116` background
- **Zoom controls:** Bottom-right glass panel with −/Fit/+. Zoom level tracked via useRef (not state) — onZoom fires during ForceGraph2D's render loop, which would throw "setState during render"
- **Select caret:** Native browser arrow replaced with inline SVG chevron + appearance: none

## Admin pages
- **Critical bug — dropdown actions broken:** Installed library is Base UI (`@base-ui/react/menu`), not Radix. Base UI uses `onClick`, not `onSelect`. Every action was a no-op (View detail, Re-index, Reset password, Promote to admin, Delete). Fixed across ReposTable and users page.
- **Delete repo dialog simplified:** Removed "type the name to confirm" pattern. Just "Are you sure?" with Cancel + Delete.
- **DomainCard spacing:** Verified toggle was overlapping the regenerate button. Adjusted right offset.

## Auth
- **Account switch bug:** AuthProvider fetches `/api/auth/me` only on initial mount. Soft nav after re-login left `user` as null, triggering the guard on /ask and bouncing to /login. Fix: `router.push(dest)` → `window.location.assign(dest)` on login success. Full reload re-mounts AuthProvider with fresh cookie.

## From earlier in the session (separate commits)
- SSE stream cancel on chat unmount (memory leak fix)
- aria-labels on icon-only buttons (Send, Cancel, row actions, sidebar toggle)
- Error banners on all admin pages (dashboard, repos, repo detail, domains, users)
- ESC closes graph side panel
- Repo switch resets selection / hover / hidden domains
- zoomToFit re-fires on repo switch
- autoFocus on dialog inputs

## Checks
- pnpm typecheck ✓
- pnpm lint ✓